### PR TITLE
feat: make wasmPath optional with smart auto-detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@cmux/ghostty-terminal",

--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -129,8 +129,8 @@ describe('InputHandler', () => {
 
   beforeAll(async () => {
     // Load WASM once for all tests (expensive operation)
-    const wasmPath = new URL('../ghostty-vt.wasm', import.meta.url).href;
-    ghostty = await Ghostty.load(wasmPath);
+    // wasmPath is now optional - auto-detected
+    ghostty = await Ghostty.load();
   });
 
   beforeEach(() => {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -12,7 +12,7 @@ export interface ITerminalOptions {
   fontSize?: number; // Default: 15
   fontFamily?: string; // Default: 'monospace'
   allowTransparency?: boolean;
-  wasmPath?: string; // Default: '../ghostty-vt.wasm' (relative to examples/)
+  wasmPath?: string; // Optional: custom WASM path (auto-detected by default)
 }
 
 export interface ITheme {

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -37,7 +37,9 @@ export class Terminal implements ITerminalCore {
   public textarea?: HTMLTextAreaElement;
 
   // Options
-  private options: Required<ITerminalOptions>;
+  private options: Required<Omit<ITerminalOptions, 'wasmPath'>> & {
+    wasmPath?: string;
+  };
 
   // Components (created on open())
   private ghostty?: Ghostty;
@@ -79,7 +81,7 @@ export class Terminal implements ITerminalCore {
       fontSize: options.fontSize ?? 15,
       fontFamily: options.fontFamily ?? 'monospace',
       allowTransparency: options.allowTransparency ?? false,
-      wasmPath: options.wasmPath ?? '../ghostty-vt.wasm',
+      wasmPath: options.wasmPath, // Optional - Ghostty.load() handles defaults
     };
 
     this.cols = this.options.cols;

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -21,7 +21,7 @@ echo "✓ Found Zig $ZIG_VERSION"
 GHOSTTY_DIR="/tmp/ghostty-for-wasm"
 if [ ! -d "$GHOSTTY_DIR" ]; then
     echo "📦 Cloning Ghostty..."
-    git clone --depth=1 https://github.com/ghostty-org/ghostty.git "$GHOSTTY_DIR"
+    git clone --depth=1 https://github.com/coder/ghostty.git "$GHOSTTY_DIR"
 else
     echo "📦 Updating Ghostty..."
     cd "$GHOSTTY_DIR"


### PR DESCRIPTION
- Make Ghostty.load() wasmPath parameter optional with intelligent fallback logic
- Try multiple default paths: import.meta.url, relative, and root paths
- Update Terminal class to remove hardcoded wasmPath default
- Simplify test code to use auto-detection
- Fix build-wasm.sh to reference coder/ghostty repository
- Improve error messages with helpful guidance