### PR TITLE
chore: add postinstall script to support git installations

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,18 @@ bun add @coder/ghostty-web
 yarn add @coder/ghostty-web
 ```
 
+### Installing from Git
+
+You can install directly from GitHub:
+
+```bash
+npm install github:coder/ghostty-web
+# or
+bun add github:coder/ghostty-web
+```
+
+**Note:** When installing from git, the package automatically builds itself via a `postinstall` script. This requires Bun to be installed and may take a few seconds during installation.
+
 ## Basic Usage
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A web-based terminal emulator that integrates [Ghostty's](https://github.com/gho
 npm install @coder/ghostty-web
 ```
 
+Or install from GitHub:
+
+```bash
+npm install github:coder/ghostty-web
+```
+
+**Note:** Git installs will auto-build during `postinstall` (requires Bun).
+
 ## Quick Start
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "fmt:fix": "prettier --write .",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "prepublishOnly": "bun run test && bun run build"
+    "prepublishOnly": "bun run test && bun run build",
+    "postinstall": "[ -d dist ] || bun run build"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
- Add postinstall script that builds the package if dist/ is missing
- This fixes installations from git where dist/ is not committed
- For npm registry installs, the script skips build (dist/ already exists)
- Update INSTALL.md and README.md with git installation instructions

Fixes git installations by automatically building the package after clone. Requires Bun to be installed. Takes ~3-5 seconds during install.