### PR TITLE
Enable linefeed mode so newline moves cursor to column 0

### DIFF
--- a/patches/ghostty-wasm-api.patch
+++ b/patches/ghostty-wasm-api.patch
@@ -622,7 +622,7 @@ new file mode 100644
 index 000000000..e79702488
 --- /dev/null
 +++ b/src/terminal/c/terminal.zig
-@@ -0,0 +1,638 @@
+@@ -0,0 +1,642 @@
 +//! C API wrapper for Terminal
 +//!
 +//! This provides a C-compatible interface to Ghostty's Terminal for WASM export.


### PR DESCRIPTION
## Summary
- Enable linefeed mode when creating new terminal instances so `\n` properly moves cursor to column 0
- Without this PR the result does not render correctly if it uses \n for new lines instead of \r\n

## Problem
Without linefeed mode enabled, `\n` only moves the cursor down without returning to column 0. This causes text to display in a staggered pattern:

```
Line 1
      Line 2
            Line 3
```

## Solution
Set `wrapper.terminal.modes.set(.linefeed, true)` after terminal creation in the WASM API. This makes `\n` behave as expected (LF + CR), properly returning the cursor to column 0:

```
Line 1
Line 2
Line 3
```