### PR TITLE
Adding the missing package descriptions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "vite": "^4.5.0",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "@lydell/node-pty": "^1.1.0",
+    "ws": "^8.18.3"
   }
 }


### PR DESCRIPTION
To launch the demo service, `node-pty` and `ws` are required.