### PR TITLE
Added support for IME input for languages such as Chinese and Japanese.

### DIFF
--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -52,8 +52,8 @@ function createKeyEvent(
     shiftKey: modifiers.shift ?? false,
     metaKey: modifiers.meta ?? false,
     repeat: false,
-    preventDefault: mock(() => { }),
-    stopPropagation: mock(() => { }),
+    preventDefault: mock(() => {}),
+    stopPropagation: mock(() => {}),
   };
 }
 
@@ -69,14 +69,14 @@ function createClipboardEvent(text: string | null): MockClipboardEvent {
     clipboardData:
       text !== null
         ? {
-          getData: (format: string) => data.get(format) || '',
-          setData: (format: string, value: string) => {
-            data.set(format, value);
-          },
-        }
+            getData: (format: string) => data.get(format) || '',
+            setData: (format: string, value: string) => {
+              data.set(format, value);
+            },
+          }
         : null,
-    preventDefault: mock(() => { }),
-    stopPropagation: mock(() => { }),
+    preventDefault: mock(() => {}),
+    stopPropagation: mock(() => {}),
   };
 }
 interface MockCompositionEvent {
@@ -94,8 +94,8 @@ function createCompositionEvent(
   return {
     type,
     data,
-    preventDefault: mock(() => { }),
-    stopPropagation: mock(() => { }),
+    preventDefault: mock(() => {}),
+    stopPropagation: mock(() => {}),
   };
 }
 // Helper to create mock container
@@ -140,7 +140,7 @@ function createMockContainer(): MockHTMLElement & {
     appendChild(node: Node) {
       this.childNodes.push(node);
       return node;
-    }
+    },
   };
 }
 

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -239,22 +239,13 @@ export class InputHandler {
     this.container.addEventListener('paste', this.pasteListener);
 
     this.compositionStartListener = this.handleCompositionStart.bind(this);
-    this.container.addEventListener(
-      'compositionstart',
-      this.compositionStartListener
-    );
+    this.container.addEventListener('compositionstart', this.compositionStartListener);
 
     this.compositionUpdateListener = this.handleCompositionUpdate.bind(this);
-    this.container.addEventListener(
-      'compositionupdate',
-      this.compositionUpdateListener
-    );
+    this.container.addEventListener('compositionupdate', this.compositionUpdateListener);
 
     this.compositionEndListener = this.handleCompositionEnd.bind(this);
-    this.container.addEventListener(
-      'compositionend',
-      this.compositionEndListener
-    );
+    this.container.addEventListener('compositionend', this.compositionEndListener);
   }
 
   /**
@@ -587,26 +578,17 @@ export class InputHandler {
     }
 
     if (this.compositionStartListener) {
-      this.container.removeEventListener(
-        'compositionstart',
-        this.compositionStartListener
-      );
+      this.container.removeEventListener('compositionstart', this.compositionStartListener);
       this.compositionStartListener = null;
     }
 
     if (this.compositionUpdateListener) {
-      this.container.removeEventListener(
-        'compositionupdate',
-        this.compositionUpdateListener
-      );
+      this.container.removeEventListener('compositionupdate', this.compositionUpdateListener);
       this.compositionUpdateListener = null;
     }
 
     if (this.compositionEndListener) {
-      this.container.removeEventListener(
-        'compositionend',
-        this.compositionEndListener
-      );
+      this.container.removeEventListener('compositionend', this.compositionEndListener);
       this.compositionEndListener = null;
     }
 


### PR DESCRIPTION
Initial support for Chinese, Japanese, and other input methods has been implemented. This is a preliminary version that may require further optimization, but it stably achieves the target functionality without negative impacts.

Compared to before the modification, input was not possible:

<img width="1081" height="715" alt="Screenshot 2025-12-04 at 12 40 24 PM" src="https://github.com/user-attachments/assets/004f3acc-c710-47e0-8616-a274eea3bbbe" />

This is the revised effect, which meets expectations:

<img width="1140" height="708" alt="Screenshot 2025-12-04 at 1 40 44 PM" src="https://github.com/user-attachments/assets/c969a204-931c-45ce-b7fb-e6d751ca37fb" />
