### PR TITLE
fix: check for bracketed paste mode in input handler

### DIFF
--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -506,10 +506,16 @@ export class InputHandler {
       return;
     }
 
-    // Send the text to the terminal
-    // Note: For bracketed paste mode, we would wrap this in \x1b[200~ ... \x1b[201~
-    // but for now, send raw text
-    this.onDataCallback(text);
+    // Check if bracketed paste mode is enabled (DEC mode 2004)
+    const hasBracketedPaste = this.getModeCallback?.(2004) ?? false;
+
+    if (hasBracketedPaste) {
+      // Wrap with bracketed paste sequences
+      this.onDataCallback('\x1b[200~' + text + '\x1b[201~');
+    } else {
+      // Send raw text
+      this.onDataCallback(text);
+    }
   }
 
   /**


### PR DESCRIPTION
i'm using `ghostty-web` in an experimental [jupyter lab extension](https://github.com/eexwhyzee/jupyterlab-ghostty) to replace its built-in terminal, and noticed that the bracketed paste was not working correctly.

I looked into the input handler code and saw that the fix is pretty much noted in the existing doc string haha so this PR just updates the input handler to check if bracketed paste mode is enabled, if so, wrap the text in the paste sequences.

## Testing
i tested a local build of `ghostty-web` with my jupyter lab extension and it was working as expected, i also ran the demo locally to confirm the fix as well

before the fix:
<img width="618" height="320" alt="Screenshot 2025-12-12 at 1 53 54 PM" src="https://github.com/user-attachments/assets/fb7b3550-9ecc-49fa-8592-9cf240f0292c" />


after the fix:
<img width="710" height="269" alt="Screenshot 2025-12-12 at 1 54 37 PM" src="https://github.com/user-attachments/assets/97656141-fc94-40bb-b63c-38bade85be85" />

