### PR TITLE
fix: allow processing multiple terminal responses from WASM

### DIFF
--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -1759,8 +1759,9 @@ export class Terminal implements ITerminalCore {
 
     // Read all pending responses from the WASM terminal
     // Multiple responses can be queued if a single write() contained multiple queries
-    let response: string | null;
-    while ((response = this.wasmTerm.readResponse()) !== null) {
+    while (true) {
+      const response = this.wasmTerm.readResponse();
+      if (response === null) break;
       // Send response back to the PTY via onData
       // This is the same path as user keyboard input
       this.dataEmitter.fire(response);


### PR DESCRIPTION
this fix addresses a hanging issue when terminal integrations that buffer incoming data during async initialization (for example: https://github.com/jupyterlab/jupyterlab/blob/main/packages/terminal/src/widget.ts#L75-L115) can trigger multiple terminal query responses in a single write call.

things like neovim/nushell that send multiple queries and block waiting for responses, which hangs because currently only the first response was being sent back.

for example, trying to run neovim in jupyterlab would hang after the first response:
<img width="910" height="374" alt="Screenshot 2025-12-13 at 2 12 58 PM" src="https://github.com/user-attachments/assets/7a1a1d21-5973-41af-9dfd-6c837a56a659" />

after the fix, neovim starts up successfully in jupyterlab:
<img width="1189" height="342" alt="Screenshot 2025-12-13 at 2 11 19 PM" src="https://github.com/user-attachments/assets/9f4a92a4-0c69-47eb-a13c-456af0d0ef73" />

