### PR TITLE
fix: send backtab escape sequence on Shift+Tab

### DIFF
--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -370,7 +370,11 @@ export class InputHandler {
           simpleOutput = '\r'; // Carriage return
           break;
         case Key.TAB:
-          simpleOutput = '\t'; // Tab
+          if (mods === Mods.SHIFT) {
+            simpleOutput = '\x1b[Z'; // Backtab
+          } else {
+            simpleOutput = '\t'; // Tab
+          }
           break;
         case Key.BACKSPACE:
           simpleOutput = '\x7F'; // DEL (most terminals use 0x7F for backspace)


### PR DESCRIPTION
Modified the TAB case in handleKeyDown to check for Shift modifier and send backtab escape sequence (\x1b[Z) instead of regular tab.

https://github.com/coder/ghostty-web/issues/109 Keyboard handling issues: Shift+Tab on macOS