### PR TITLE
fix: clear canvas before filling to support transparent backgrounds

### DIFF
--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -794,7 +794,6 @@ export class CanvasRenderer {
       this.theme.brightCyan,
       this.theme.brightWhite,
     ];
-
   }
 
   /**


### PR DESCRIPTION
# Problem

When setting the terminal background to a translucent or transparent background, the canvas writing approach ends up stacking up stale content. This PR fixes that.

My first draft actually looked at the background color to decide if it was opaque and then skipped the `clearRect` for that scenario, however I don't think there is a perf hit here so have gone for the more simple approach, if you'd prefer this other approach then please let me know 🙂

## Summary
- Add `clearRect` before `fillRect` in canvas rendering methods to properly clear previous content
- Fixes content piling up when using transparent/translucent background colors
- Ensures selection highlighting clears properly with transparent backgrounds

## Test plan
- Set terminal background to a transparent color (e.g., `rgba(0,0,0,0)`)
- Verify terminal content clears properly instead of accumulating
- Verify selection highlighting works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)