### PR TITLE
fix: prevent clipboard overwrite on single click without selection

### DIFF
--- a/lib/selection-manager.ts
+++ b/lib/selection-manager.ts
@@ -550,10 +550,12 @@ export class SelectionManager {
         this.isSelecting = false;
         this.stopAutoScroll();
 
-        const text = this.getSelection();
-        if (text) {
-          this.copyToClipboard(text);
-          this.selectionChangedEmitter.fire();
+        if (this.hasSelection()) {
+          const text = this.getSelection();
+          if (text) {
+            this.copyToClipboard(text);
+            this.selectionChangedEmitter.fire();
+          }
         }
       }
     };


### PR DESCRIPTION
## Summary
Fixes #108

Single clicks on terminal cells were triggering `copyToClipboard()` in the `mouseup` handler without checking `hasSelection()` first. This caused the user's clipboard to be silently overwritten with a single character from the clicked cell, even when no text was selected.

## Changes
- Added `hasSelection()` guard in the `mouseup` handler in `SelectionManager`, matching the existing pattern in the public `copySelection()` API

## Root Cause
The `mousedown` handler sets both `selectionStart` and `selectionEnd` to the same cell on click, and `isSelecting = true`. When `mouseup` fires (without any drag), `getSelection()` returns the character at that single cell, and `copyToClipboard()` overwrites the clipboard. The `hasSelection()` method correctly identifies same-cell selections as not real selections, but the `mouseup` handler wasn't calling it.

## Test Plan
- Click on a terminal cell without dragging → clipboard should NOT be modified
- Click and drag to select text → clipboard should contain selected text
- Double-click to select a word → clipboard should contain the word
- Cmd+C with selection → should still copy correctly

---
🤖 Generated with Claude Code (issue-hunter-pro)