### PR TITLE
docs: correct GhosttyTerminalConfig.scrollbackLimit docs

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -532,6 +532,7 @@ export const COLORS_STRUCT_SIZE = 12;
  * All color values use 0xRRGGBB format. A value of 0 means "use default".
  */
 export interface GhosttyTerminalConfig {
+  /** Scrollback buffer size in bytes. Passed to Terminal.max_scrollback. */
   scrollbackLimit?: number;
   fgColor?: number;
   bgColor?: number;
@@ -604,7 +605,7 @@ export interface Cursor {
  * Terminal configuration (passed to ghostty_terminal_new_with_config)
  */
 export interface TerminalConfig {
-  scrollback_limit: number; // Number of scrollback lines (default: 10,000)
+  scrollback_limit: number; // Scrollback buffer size in bytes (default: 10,000)
   fg_color: RGB; // Default foreground color
   bg_color: RGB; // Default background color
 }


### PR DESCRIPTION
scrollback_limit is passed to ghostty's Terminal.max_scrollback, which is in bytes. The low-level config types described it as "number of scrollback lines", which is misleading — a caller passing 10,000 expecting lines gets 10,000 bytes and falls below the 2-page PageList floor.

Only the low-level GhosttyTerminalConfig / TerminalConfig docs are corrected here. The xterm.js-compat ITerminalOptions.scrollback field still inherits xterm.js-compat framing and a misleadingly xterm.js- shaped default (1000) despite plumbing directly to a bytes-valued field; fixing that properly requires a lines-to-bytes conversion somewhere. Happy to contribute this if required.