### PR TITLE
fix: handle URLs with balanced parentheses in URL detection

### DIFF
--- a/lib/providers/url-regex-provider.ts
+++ b/lib/providers/url-regex-provider.ts
@@ -30,13 +30,13 @@ export class UrlRegexProvider implements ILinkProvider {
    * Excludes file paths (no ./ or ../ or bare /)
    */
   private static readonly URL_REGEX =
-    /(?:https?:\/\/|mailto:|ftp:\/\/|ssh:\/\/|git:\/\/|tel:|magnet:|gemini:\/\/|gopher:\/\/|news:)[\w\-.~:\/?#@!$&*+,;=%]+/gi;
+    /(?:https?:\/\/|mailto:|ftp:\/\/|ssh:\/\/|git:\/\/|tel:|magnet:|gemini:\/\/|gopher:\/\/|news:)[\w\-.~:\/?#@!$&*+,;=%()]+/gi;
 
   /**
    * Characters to strip from end of URLs
    * Common punctuation that's unlikely to be part of the URL
    */
-  private static readonly TRAILING_PUNCTUATION = /[.,;!?)\]]+$/;
+  private static readonly TRAILING_PUNCTUATION = /[.,;!?\]]+$/;
 
   constructor(private terminal: ITerminalForUrlProvider) {}
 
@@ -70,6 +70,18 @@ export class UrlRegexProvider implements ILinkProvider {
       if (stripped.length < url.length) {
         url = stripped;
         endX = startX + url.length - 1;
+      }
+
+      // Strip unbalanced trailing parentheses
+      while (url.endsWith(')')) {
+        const open = url.split('(').length - 1;
+        const close = url.split(')').length - 1;
+        if (close > open) {
+          url = url.slice(0, -1);
+          endX--;
+        } else {
+          break;
+        }
       }
 
       // Skip if URL is too short (e.g., just "http://")

--- a/lib/url-detection.test.ts
+++ b/lib/url-detection.test.ts
@@ -178,6 +178,46 @@ describe('URL Detection', () => {
     expect(links?.[0].text).toBe('tel:+1234567890');
   });
 
+  test('detects URLs with balanced parentheses (Wikipedia)', async () => {
+    const links = await getLinks(
+      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
+    );
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe(
+      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
+    );
+  });
+
+  test('strips unbalanced trailing paren from wrapped URL', async () => {
+    const links = await getLinks(
+      '(see https://en.wikipedia.org/wiki/Rust_(programming_language))'
+    );
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe(
+      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
+    );
+  });
+
+  test('handles URL with multiple parenthesized path segments', async () => {
+    const links = await getLinks(
+      'https://example.com/a_(b)/c_(d)'
+    );
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe('https://example.com/a_(b)/c_(d)');
+  });
+
+  test('handles URL with nested parentheses', async () => {
+    const links = await getLinks(
+      'https://example.com/foo_(bar_(baz))'
+    );
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe('https://example.com/foo_(bar_(baz))');
+  });
+
   test('detects magnet: URLs', async () => {
     const links = await getLinks('Download magnet:?xt=urn:btih:abc123');
     expect(links).toBeDefined();

--- a/lib/url-detection.test.ts
+++ b/lib/url-detection.test.ts
@@ -179,40 +179,28 @@ describe('URL Detection', () => {
   });
 
   test('detects URLs with balanced parentheses (Wikipedia)', async () => {
-    const links = await getLinks(
-      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
-    );
+    const links = await getLinks('https://en.wikipedia.org/wiki/Rust_(programming_language)');
     expect(links).toBeDefined();
     expect(links?.length).toBe(1);
-    expect(links?.[0].text).toBe(
-      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
-    );
+    expect(links?.[0].text).toBe('https://en.wikipedia.org/wiki/Rust_(programming_language)');
   });
 
   test('strips unbalanced trailing paren from wrapped URL', async () => {
-    const links = await getLinks(
-      '(see https://en.wikipedia.org/wiki/Rust_(programming_language))'
-    );
+    const links = await getLinks('(see https://en.wikipedia.org/wiki/Rust_(programming_language))');
     expect(links).toBeDefined();
     expect(links?.length).toBe(1);
-    expect(links?.[0].text).toBe(
-      'https://en.wikipedia.org/wiki/Rust_(programming_language)'
-    );
+    expect(links?.[0].text).toBe('https://en.wikipedia.org/wiki/Rust_(programming_language)');
   });
 
   test('handles URL with multiple parenthesized path segments', async () => {
-    const links = await getLinks(
-      'https://example.com/a_(b)/c_(d)'
-    );
+    const links = await getLinks('https://example.com/a_(b)/c_(d)');
     expect(links).toBeDefined();
     expect(links?.length).toBe(1);
     expect(links?.[0].text).toBe('https://example.com/a_(b)/c_(d)');
   });
 
   test('handles URL with nested parentheses', async () => {
-    const links = await getLinks(
-      'https://example.com/foo_(bar_(baz))'
-    );
+    const links = await getLinks('https://example.com/foo_(bar_(baz))');
     expect(links).toBeDefined();
     expect(links?.length).toBe(1);
     expect(links?.[0].text).toBe('https://example.com/foo_(bar_(baz))');


### PR DESCRIPTION
## Problem

URLs containing parentheses — such as Wikipedia links like `https://en.wikipedia.org/wiki/Rust_(programming_language)` — are incorrectly truncated. The URL regex character class excludes `(` and `)`, so the match stops at the first parenthesis. Additionally, `TRAILING_PUNCTUATION` unconditionally strips `)`, breaking URLs where parentheses are part of the path.

## Fix

- Add `()` to the URL regex character class so parentheses are captured
- Remove `)` from `TRAILING_PUNCTUATION` to preserve balanced parens
- Add a balanced-paren stripping pass: only strip trailing `)` when the URL has more close-parens than open-parens (handles the common case of a URL wrapped in prose parentheses like `(see https://...)`)

## Test Plan

- `bun test lib/url-detection.test.ts` — 24/24 pass (4 new tests for parens handling)
- `biome check .` — clean
- `tsc --noEmit` — clean
- Existing test `'strips trailing parenthesis'` with `(see https://example.com)` still passes