### PR TITLE
fix(input): let Shift+Enter reach the encoder

### DIFF
--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -570,6 +570,24 @@ describe('InputHandler', () => {
       expect(dataReceived[0]).toBe('\r');
     });
 
+    test('Shift+Enter is distinguishable from Enter', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      simulateKey(container, createKeyEvent('Enter', 'Enter', { shift: true }));
+
+      expect(dataReceived.length).toBe(1);
+      // Shift+Enter must not collapse to plain \r — apps using the Kitty
+      // keyboard protocol or xterm modifyOtherKeys rely on it being distinct.
+      expect(dataReceived[0]).not.toBe('\r');
+    });
+
     test('encodes Tab', () => {
       const handler = new InputHandler(
         ghostty,

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -422,7 +422,13 @@ export class InputHandler {
     const mods = this.extractModifiers(event);
 
     // Handle simple special keys that produce standard sequences
-    if (mods === Mods.NONE || mods === Mods.SHIFT) {
+    //
+    // Shift+Enter is intentionally excluded: apps using the Kitty keyboard
+    // protocol or xterm modifyOtherKeys rely on Shift+Enter being
+    // distinguishable from Enter (e.g. "newline without submit" in REPLs,
+    // Claude Code, some chat clients). Let it fall through to the encoder,
+    // which emits \x1b[13;2u (Kitty) or \x1b[27;2;13~ (modifyOtherKeys).
+    if (mods === Mods.NONE || (mods === Mods.SHIFT && key !== Key.ENTER)) {
       let simpleOutput: string | null = null;
 
       switch (key) {


### PR DESCRIPTION
## Summary

Shift+Enter is currently short-circuited to `\r` alongside plain Enter in `InputHandler.handleKeyDown`, discarding the Shift modifier before the encoder can emit a distinct sequence. Apps that opt into the Kitty keyboard protocol or xterm modifyOtherKeys rely on Shift+Enter being distinguishable from Enter (e.g. "newline without submit" in REPLs, chat clients, Claude Code).

This PR excludes `Key.ENTER` from the Shift branch of the modifier-shortcut guard so Shift+Enter falls through to the encoder, which emits `\x1b[13;2u` (Kitty) or `\x1b[27;2;13~` (modifyOtherKeys).

Plain Enter and all other Shift+Key shortcuts (Shift+Tab → reverse-tab, etc.) are unchanged.

## Test plan

- [x] Existing `encodes Enter` test still passes (Enter → `\r`)
- [x] New `Shift+Enter is distinguishable from Enter` test asserts output is not `\r`
- [x] Full suite: 334/334 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)