### PR TITLE
fix: respect scroll position when new output arrives

### DIFF
--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -575,8 +575,10 @@ export class Terminal implements ITerminalCore {
     // Invalidate link cache (content changed)
     this.linkDetector?.invalidateCache();
 
-    // Phase 2: Auto-scroll to bottom on new output (xterm.js behavior)
-    if (this.viewportY !== 0) {
+    // Phase 2: Auto-scroll to bottom on new output, but only if the user
+    // is already following output at the bottom. If they've scrolled into
+    // history, respect their position (matches xterm.js behavior).
+    if (this.viewportY <= 0.5) {
       this.scrollToBottom();
     }
 


### PR DESCRIPTION
Previously, `writeInternal` called `scrollToBottom()` whenever `viewportY` was not exactly 0, yanking the user back to the bottom on every incoming byte. This made it impossible to scroll up and read history while a process was producing output.

Now it only auto-scrolls when the user is already following output at the bottom (`viewportY <= 0.5`, handling fractional positions from smooth-scrolling). Matches xterm.js behavior: if the user scrolled into history, new output doesn't disrupt their position.