### PR TITLE
fix(demo): secure WebSocket PTY access

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Originally created for [Mux](https://github.com/coder/mux) (a desktop app for is
   npx @ghostty-web/demo@next
   ```
 
-  This starts a local HTTP server with a real shell on `http://localhost:8080`. Works best on Linux and macOS.
+  This starts a loopback-only HTTP server with a real shell on `http://127.0.0.1:8080`. The demo protects `/ws` with a per-run same-origin token and rejects cross-origin WebSocket handshakes. Works best on Linux and macOS.
+
+  To intentionally bind somewhere else, set `HOST=<host>`. If you serve the demo through extra hostnames or a wildcard bind such as `HOST=0.0.0.0`, also set `GHOSTTY_ALLOWED_HOSTS=host1,host2`. Avoid remote exposure unless you understand the risk: the demo starts a real local shell.
 
 ![ghostty](https://github.com/user-attachments/assets/aceee7eb-d57b-4d89-ac3d-ee1885d0187a)
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -13,11 +13,12 @@ Works on **Linux** and **macOS** (no Windows support yet).
 
 ## What it does
 
-- Starts an HTTP server on port 8080 (configurable via `PORT` env var)
+- Starts an HTTP server on `127.0.0.1:8080` by default (`PORT` and `HOST` are configurable)
 - Serves WebSocket PTY on the same port at `/ws` endpoint
+- Protects `/ws` with a per-run same-origin token from `/api/token`
+- Rejects cross-origin WebSocket handshakes
 - Opens a real shell session (bash, zsh, etc.)
 - Provides full PTY support (colors, cursor positioning, resize, etc.)
-- Supports reverse proxies (ngrok, nginx, etc.) via X-Forwarded-\* headers
 
 ## Usage
 
@@ -27,31 +28,18 @@ npx @ghostty-web/demo@next
 
 # Custom port
 PORT=3000 npx @ghostty-web/demo@next
+
+# Explicit bind host for intentional non-default access
+HOST=192.0.2.10 GHOSTTY_ALLOWED_HOSTS=demo.example npx @ghostty-web/demo@next
 ```
 
-Then open http://localhost:8080 in your browser.
+Then open http://127.0.0.1:8080 in your browser.
 
-## Reverse Proxy Support
+## Bind host and proxy configuration
 
-The server now supports reverse proxies like ngrok, nginx, and others by:
+The demo binds to `127.0.0.1` by default and only allows loopback hostnames (`localhost`, `127.0.0.1`, and `::1`) unless configured otherwise. Set `HOST=<host>` to change the bind address. If you serve the demo through another hostname, or bind to a wildcard such as `HOST=0.0.0.0`, add the browser-visible hostnames with `GHOSTTY_ALLOWED_HOSTS=host1,host2`.
 
-- Serving WebSocket on the same HTTP port (no separate port needed)
-- Using relative WebSocket URLs on the client side
-- Automatic protocol detection (HTTP/HTTPS, WS/WSS)
-
-This means the WebSocket connection automatically adapts to use the same protocol and host as the HTTP connection, making it work seamlessly through any reverse proxy.
-
-### Example with ngrok
-
-```bash
-# Start the demo server
-npx @ghostty-web/demo@next
-
-# In another terminal, expose it via ngrok
-ngrok http 8080
-```
-
-The terminal will work seamlessly through the ngrok URL! Both HTTP and WebSocket traffic will be properly proxied.
+The browser client fetches `/api/token` from the same origin before opening `/ws`, and the server rejects `/ws` when the token is missing, the `Host` is not allowed, or the WebSocket `Origin` does not match the request host. Do not set permissive CORS in front of `/api/token`.
 
 ### Example with nginx
 
@@ -66,10 +54,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
 ```
@@ -78,4 +62,4 @@ server {
 
 ⚠️ **This server provides full shell access.**
 
-Only use for local development and demos. Do not expose to untrusted networks.
+Only use for local development and demos. Keep the default loopback bind unless you intentionally need remote access and have configured `HOST` and `GHOSTTY_ALLOWED_HOSTS` for the exact hostnames you trust.

--- a/demo/bin/auth.js
+++ b/demo/bin/auth.js
@@ -1,0 +1,335 @@
+import assert from 'assert';
+import { randomBytes, timingSafeEqual } from 'crypto';
+import { isIP } from 'net';
+
+const LOOPBACK_HOSTS = Object.freeze(['localhost', '127.0.0.1', '::1']);
+const WILDCARD_BIND_HOSTS = Object.freeze(['0.0.0.0', '::', '*']);
+
+function decision(status, reason) {
+  return { ok: false, status, reason };
+}
+
+function badRequest() {
+  return decision(400, 'Bad Request');
+}
+
+function forbidden() {
+  return decision(403, 'Forbidden');
+}
+
+function unauthorized() {
+  return decision(401, 'Unauthorized');
+}
+
+function parseAllowedHosts(value) {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((host) => host.trim())
+    .filter((host) => host.length > 0);
+}
+
+function normalizeHostname(hostname) {
+  if (typeof hostname !== 'string') {
+    return null;
+  }
+
+  let value = hostname.trim().toLowerCase();
+  if (value.length === 0 || /\s/.test(value)) {
+    return null;
+  }
+
+  if (value.startsWith('[') || value.endsWith(']')) {
+    if (!value.startsWith('[') || !value.endsWith(']')) {
+      return null;
+    }
+    value = value.slice(1, -1);
+  }
+
+  if (value.length === 0 || value.includes('/') || value.includes('\\') || value.includes('@')) {
+    return null;
+  }
+
+  if (isIP(value) !== 0) {
+    return value;
+  }
+
+  if (value.includes(':') || !/^[a-z0-9.-]+$/.test(value)) {
+    return null;
+  }
+
+  const labels = value.split('.');
+  if (labels.some((label) => label.length === 0 || label.length > 63)) {
+    return null;
+  }
+
+  for (const label of labels) {
+    if (label.startsWith('-') || label.endsWith('-')) {
+      return null;
+    }
+  }
+
+  return value;
+}
+
+function addAllowedHost(allowedHosts, host) {
+  const normalized = normalizeHostname(host);
+  assert(normalized, `Allowed host must be a hostname or IP address: ${host}`);
+  allowedHosts.add(normalized);
+}
+
+function parsePort(port) {
+  if (port === undefined || port === '') {
+    return '';
+  }
+  if (!/^[0-9]+$/.test(port)) {
+    return null;
+  }
+  const value = Number.parseInt(port, 10);
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    return null;
+  }
+  return String(value);
+}
+
+export function parseHostHeader(hostHeader) {
+  if (
+    typeof hostHeader !== 'string' ||
+    hostHeader.length === 0 ||
+    hostHeader.trim() !== hostHeader
+  ) {
+    return null;
+  }
+
+  let hostname = '';
+  let port = '';
+
+  if (hostHeader.startsWith('[')) {
+    const match = /^\[([^\]]+)\](?::([0-9]+))?$/.exec(hostHeader);
+    if (!match) {
+      return null;
+    }
+    hostname = match[1];
+    const parsedPort = parsePort(match[2]);
+    if (parsedPort === null) {
+      return null;
+    }
+    port = parsedPort;
+  } else {
+    const colonCount = (hostHeader.match(/:/g) || []).length;
+    if (colonCount === 0) {
+      hostname = hostHeader;
+    } else if (colonCount === 1) {
+      const parts = hostHeader.split(':');
+      hostname = parts[0];
+      const parsedPort = parsePort(parts[1]);
+      if (parsedPort === null) {
+        return null;
+      }
+      port = parsedPort;
+    } else {
+      hostname = hostHeader;
+    }
+  }
+
+  const normalizedHostname = normalizeHostname(hostname);
+  if (!normalizedHostname) {
+    return null;
+  }
+
+  return { hostname: normalizedHostname, port };
+}
+
+function parseOriginHeader(originHeader) {
+  if (
+    typeof originHeader !== 'string' ||
+    originHeader.length === 0 ||
+    originHeader.trim() !== originHeader
+  ) {
+    return null;
+  }
+
+  let origin;
+  try {
+    origin = new URL(originHeader);
+  } catch (_error) {
+    return null;
+  }
+
+  if (origin.protocol !== 'http:' && origin.protocol !== 'https:') {
+    return null;
+  }
+
+  if (
+    origin.username ||
+    origin.password ||
+    origin.pathname !== '/' ||
+    origin.search ||
+    origin.hash
+  ) {
+    return null;
+  }
+
+  const host = parseHostHeader(origin.host);
+  if (!host) {
+    return null;
+  }
+
+  return { protocol: origin.protocol, ...host };
+}
+
+function defaultPort(protocol) {
+  assert(protocol === 'http:' || protocol === 'https:', `Unexpected origin protocol: ${protocol}`);
+  return protocol === 'https:' ? '443' : '80';
+}
+
+function originMatchesHost(origin, host) {
+  const fallbackPort = defaultPort(origin.protocol);
+  return (
+    origin.hostname === host.hostname &&
+    (origin.port || fallbackPort) === (host.port || fallbackPort)
+  );
+}
+
+function validateAllowedHost(config, hostHeader) {
+  assertAuthConfig(config);
+  const host = parseHostHeader(hostHeader);
+  if (!host) {
+    return { ...badRequest(), host: null };
+  }
+
+  if (!config.allowedHosts.includes(host.hostname)) {
+    return { ...forbidden(), host };
+  }
+
+  return { ok: true, host };
+}
+
+function validateMatchingOrigin(originHeader, host, required) {
+  if (originHeader === undefined && !required) {
+    return { ok: true };
+  }
+
+  if (originHeader === undefined) {
+    return forbidden();
+  }
+
+  const origin = parseOriginHeader(originHeader);
+  if (!origin) {
+    return badRequest();
+  }
+
+  if (!originMatchesHost(origin, host)) {
+    return forbidden();
+  }
+
+  return { ok: true };
+}
+
+function safeTokenEquals(expected, actual) {
+  assert(
+    typeof expected === 'string' && expected.length > 0,
+    'Expected auth token must be non-empty'
+  );
+  if (typeof actual !== 'string' || actual.length === 0) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+}
+
+function assertAuthConfig(config) {
+  assert(config && typeof config === 'object', 'Auth config must be an object');
+  assert(
+    typeof config.token === 'string' && config.token.length > 0,
+    'Auth token must be non-empty'
+  );
+  assert(
+    Array.isArray(config.allowedHosts) && config.allowedHosts.length > 0,
+    'Allowed host list must be non-empty'
+  );
+}
+
+export function generateSessionToken() {
+  const token = randomBytes(32).toString('base64url');
+  assert(token.length >= 32, 'Generated session token must contain enough entropy');
+  return token;
+}
+
+export function isWildcardBindHost(host) {
+  const normalized = normalizeHostname(host);
+  return (
+    WILDCARD_BIND_HOSTS.includes(host) ||
+    (normalized !== null && WILDCARD_BIND_HOSTS.includes(normalized))
+  );
+}
+
+export function isLoopbackHost(host) {
+  const normalized = normalizeHostname(host);
+  return normalized !== null && LOOPBACK_HOSTS.includes(normalized);
+}
+
+export function createAuthConfig(options = {}) {
+  const env = options.env ?? process.env;
+  const bindHost = options.bindHost ?? env.HOST ?? '127.0.0.1';
+  const token = options.token ?? generateSessionToken();
+
+  assert(typeof bindHost === 'string' && bindHost.length > 0, 'Bind host must be non-empty');
+  assert(typeof token === 'string' && token.length > 0, 'Auth token must be non-empty');
+  assert(LOOPBACK_HOSTS.length > 0, 'Loopback host allowlist must not be empty');
+
+  const allowedHosts = new Set(LOOPBACK_HOSTS);
+  for (const host of options.allowedHosts ?? parseAllowedHosts(env.GHOSTTY_ALLOWED_HOSTS)) {
+    addAllowedHost(allowedHosts, host);
+  }
+
+  if (!isWildcardBindHost(bindHost)) {
+    addAllowedHost(allowedHosts, bindHost);
+  }
+
+  return Object.freeze({
+    token,
+    bindHost,
+    allowedHosts: Object.freeze([...allowedHosts]),
+  });
+}
+
+export function validateTokenRequest(config, request) {
+  const hostDecision = validateAllowedHost(config, request.host);
+  if (!hostDecision.ok) {
+    return hostDecision;
+  }
+
+  const originDecision = validateMatchingOrigin(request.origin, hostDecision.host, false);
+  if (!originDecision.ok) {
+    return originDecision;
+  }
+
+  return { ok: true };
+}
+
+export function validateWebSocketRequest(config, request) {
+  const hostDecision = validateAllowedHost(config, request.host);
+  if (!hostDecision.ok) {
+    return hostDecision;
+  }
+
+  const originDecision = validateMatchingOrigin(request.origin, hostDecision.host, true);
+  if (!originDecision.ok) {
+    return originDecision;
+  }
+
+  if (!safeTokenEquals(config.token, request.token)) {
+    return unauthorized();
+  }
+
+  return { ok: true };
+}

--- a/demo/bin/demo.js
+++ b/demo/bin/demo.js
@@ -739,6 +739,7 @@ if (DEV_MODE) {
       port: HTTP_PORT,
       strictPort: true,
       cors: false,
+      allowedHosts: AUTH_CONFIG.allowedHosts,
     },
   });
 

--- a/demo/bin/demo.js
+++ b/demo/bin/demo.js
@@ -18,11 +18,29 @@ import pty from '@lydell/node-pty';
 // WebSocket server
 import { WebSocketServer } from 'ws';
 
+import {
+  createAuthConfig,
+  isLoopbackHost,
+  isWildcardBindHost,
+  validateTokenRequest,
+  validateWebSocketRequest,
+} from './auth.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const DEV_MODE = process.argv.includes('--dev');
-const HTTP_PORT = process.env.PORT || (DEV_MODE ? 8000 : 8080);
+const HTTP_PORT = parsePort(process.env.PORT || (DEV_MODE ? '8000' : '8080'));
+const AUTH_CONFIG = createAuthConfig();
+const HOST = AUTH_CONFIG.bindHost;
+
+function parsePort(value) {
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`PORT must be an integer from 1 to 65535: ${value}`);
+  }
+  return port;
+}
 
 // ============================================================================
 // Locate ghostty-web assets
@@ -240,12 +258,46 @@ const HTML_TEMPLATE = `<!doctype html>
 
       // Connect to WebSocket PTY server (use same origin as HTTP server)
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = protocol + '//' + window.location.host + '/ws?cols=' + term.cols + '&rows=' + term.rows;
       let ws;
 
-      function connect() {
+      async function fetchAuthToken() {
+        const response = await fetch('/api/token', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error('Token request failed with HTTP ' + response.status);
+        }
+
+        const body = await response.json();
+        if (!body || typeof body.token !== 'string' || body.token.length === 0) {
+          throw new Error('Token response did not include a token');
+        }
+
+        return body.token;
+      }
+
+      function buildWebSocketUrl(token) {
+        const params = new URLSearchParams();
+        params.set('cols', String(term.cols));
+        params.set('rows', String(term.rows));
+        params.set('token', token);
+        return protocol + '//' + window.location.host + '/ws?' + params.toString();
+      }
+
+      async function connect() {
+        setStatus('connecting', 'Authenticating...');
+
+        let token;
+        try {
+          token = await fetchAuthToken();
+        } catch (error) {
+          console.error('Authentication failed:', error);
+          setStatus('disconnected', 'Auth error');
+          term.write('\\r\\n\\x1b[31mAuthentication failed. Retrying in 2s...\\x1b[0m\\r\\n');
+          setTimeout(connect, 2000);
+          return;
+        }
+
         setStatus('connecting', 'Connecting...');
-        ws = new WebSocket(wsUrl);
+        ws = new WebSocket(buildWebSocketUrl(token));
 
         ws.onopen = () => {
           setStatus('connected', 'Connected');
@@ -338,7 +390,16 @@ const MIME_TYPES = {
 // ============================================================================
 
 const httpServer = http.createServer((req, res) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
+  const url = parseRequestUrl(req);
+  if (!url) {
+    writeHttpDecision(res, { status: 400, reason: 'Bad Request' });
+    return;
+  }
+
+  if (handleTokenRequest(req, res, url)) {
+    return;
+  }
+
   const pathname = url.pathname;
 
   // Serve index page
@@ -381,6 +442,60 @@ function serveFile(filePath, res) {
   });
 }
 
+function parseRequestUrl(req) {
+  try {
+    return new URL(req.url || '/', 'http://127.0.0.1');
+  } catch (_error) {
+    return null;
+  }
+}
+
+function writeHttpDecision(res, decision) {
+  res.writeHead(decision.status, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(decision.reason);
+}
+
+function writeTokenResponse(res) {
+  res.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(JSON.stringify({ token: AUTH_CONFIG.token }));
+}
+
+function handleTokenRequest(req, res, url) {
+  if (url.pathname !== '/api/token') {
+    return false;
+  }
+
+  if (req.method !== 'GET') {
+    res.writeHead(405, {
+      Allow: 'GET',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    res.end('Method Not Allowed');
+    return true;
+  }
+
+  const decision = validateTokenRequest(AUTH_CONFIG, {
+    host: req.headers.host,
+    origin: req.headers.origin,
+  });
+
+  if (!decision.ok) {
+    writeHttpDecision(res, decision);
+    return true;
+  }
+
+  writeTokenResponse(res);
+  return true;
+}
+
 // ============================================================================
 // WebSocket Server (using ws package)
 // ============================================================================
@@ -416,23 +531,67 @@ function createPtySession(cols, rows) {
 // WebSocket server attached to HTTP server (same port)
 const wss = new WebSocketServer({ noServer: true });
 
-// Handle HTTP upgrade for WebSocket connections
-httpServer.on('upgrade', (req, socket, head) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
+function rejectUpgrade(socket, decision) {
+  if (socket.destroyed) {
+    return;
+  }
 
-  if (url.pathname === '/ws') {
-    // In production, consider validating req.headers.origin to prevent CSRF
-    // For development/demo purposes, we allow all origins
+  const body = decision.reason + '\n';
+  socket.write(
+    `HTTP/1.1 ${decision.status} ${decision.reason}\r\n` +
+      'Connection: close\r\n' +
+      'Content-Type: text/plain; charset=utf-8\r\n' +
+      'X-Content-Type-Options: nosniff\r\n' +
+      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      '\r\n' +
+      body
+  );
+  socket.destroy();
+}
+
+function handleWebSocketUpgrade(req, socket, head) {
+  const url = parseRequestUrl(req);
+  if (!url) {
+    rejectUpgrade(socket, { status: 400, reason: 'Bad Request' });
+    return true;
+  }
+
+  if (url.pathname !== '/ws') {
+    return false;
+  }
+
+  const decision = validateWebSocketRequest(AUTH_CONFIG, {
+    host: req.headers.host,
+    origin: req.headers.origin,
+    token: url.searchParams.get('token'),
+  });
+
+  if (!decision.ok) {
+    rejectUpgrade(socket, decision);
+    return true;
+  }
+
+  if (!socket.destroyed && !socket.readableEnded) {
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit('connection', ws, req);
     });
-  } else {
+  }
+  return true;
+}
+
+// Handle HTTP upgrade for WebSocket connections
+httpServer.on('upgrade', (req, socket, head) => {
+  if (!handleWebSocketUpgrade(req, socket, head)) {
     socket.destroy();
   }
 });
 
 wss.on('connection', (ws, req) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
+  const url = parseRequestUrl(req);
+  if (!url) {
+    ws.close();
+    return;
+  }
   const cols = Number.parseInt(url.searchParams.get('cols') || '80');
   const rows = Number.parseInt(url.searchParams.get('rows') || '24');
 
@@ -508,12 +667,17 @@ wss.on('connection', (ws, req) => {
 // Startup
 // ============================================================================
 
+function formatUrlHost(host) {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
 function printBanner(url) {
   console.log('\n' + '═'.repeat(60));
   console.log('  🚀 ghostty-web demo server' + (DEV_MODE ? ' (dev mode)' : ''));
   console.log('═'.repeat(60));
   console.log(`\n  📺 Open: ${url}`);
   console.log(`  📡 WebSocket PTY: same endpoint /ws`);
+  console.log('  🔐 WebSocket auth: per-run same-origin token');
   console.log(`  🐚 Shell: ${getShell()}`);
   console.log(`  📁 Home: ${homedir()}`);
   if (DEV_MODE) {
@@ -522,6 +686,12 @@ function printBanner(url) {
     console.log(`  📦 Using local build: ${distPath}`);
   }
   console.log('\n  ⚠️  This server provides shell access.');
+  console.log('     It binds to ' + HOST + ' and rejects cross-origin WebSockets.');
+  if (isWildcardBindHost(HOST) || !isLoopbackHost(HOST)) {
+    console.log(
+      '     Remote access requires GHOSTTY_ALLOWED_HOSTS and can expose your shell if misconfigured.'
+    );
+  }
   console.log('     Only use for local development.\n');
   console.log('═'.repeat(60));
   console.log('  Press Ctrl+C to stop.\n');
@@ -544,9 +714,31 @@ if (DEV_MODE) {
   const { createServer } = await import('vite');
   const vite = await createServer({
     root: repoRoot,
+    plugins: [
+      {
+        name: 'ghostty-demo-auth',
+        configureServer(server) {
+          server.middlewares.use((req, res, next) => {
+            const url = parseRequestUrl(req);
+            if (!url) {
+              writeHttpDecision(res, { status: 400, reason: 'Bad Request' });
+              return;
+            }
+
+            if (handleTokenRequest(req, res, url)) {
+              return;
+            }
+
+            next();
+          });
+        },
+      },
+    ],
     server: {
+      host: HOST,
       port: HTTP_PORT,
       strictPort: true,
+      cors: false,
     },
   });
 
@@ -557,30 +749,20 @@ if (DEV_MODE) {
   // This ensures our handler runs BEFORE Vite's handlers
   if (vite.httpServer) {
     vite.httpServer.prependListener('upgrade', (req, socket, head) => {
-      const pathname = req.url?.split('?')[0] || req.url || '';
-
-      // ONLY handle /ws - everything else passes through unchanged to Vite
-      if (pathname === '/ws') {
-        if (!socket.destroyed && !socket.readableEnded) {
-          wss.handleUpgrade(req, socket, head, (ws) => {
-            wss.emit('connection', ws, req);
-          });
-        }
-        // Stop here - we handled it, socket is consumed
-        // Don't call other listeners
+      // ONLY handle /ws - everything else passes through unchanged to Vite.
+      if (handleWebSocketUpgrade(req, socket, head)) {
         return;
       }
 
-      // For non-/ws paths, explicitly do nothing and let the event propagate
-      // The key is: don't return, don't touch the socket, just let it pass through
-      // Vite's handlers (which were added before ours via prependListener) will process it
+      // For non-/ws paths, explicitly do nothing and let the event propagate.
+      // The key is: don't return, don't touch the socket, just let Vite process it.
     });
   }
 
-  printBanner(`http://localhost:${HTTP_PORT}/demo/`);
+  printBanner(`http://${formatUrlHost(HOST)}:${HTTP_PORT}/demo/`);
 } else {
   // Production mode: static file server
-  httpServer.listen(HTTP_PORT, () => {
-    printBanner(`http://localhost:${HTTP_PORT}`);
+  httpServer.listen(HTTP_PORT, HOST, () => {
+    printBanner(`http://${formatUrlHost(HOST)}:${HTTP_PORT}`);
   });
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -191,11 +191,44 @@
         connectWebSocket();
       }
 
-      function connectWebSocket() {
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = `${protocol}//${window.location.host}/ws?cols=${term.cols}&rows=${term.rows}`;
+      async function fetchAuthToken() {
+        const response = await fetch('/api/token', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Token request failed with HTTP ${response.status}`);
+        }
 
-        ws = new WebSocket(wsUrl);
+        const body = await response.json();
+        if (!body || typeof body.token !== 'string' || body.token.length === 0) {
+          throw new Error('Token response did not include a token');
+        }
+
+        return body.token;
+      }
+
+      function buildWebSocketUrl(token) {
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const params = new URLSearchParams();
+        params.set('cols', String(term.cols));
+        params.set('rows', String(term.rows));
+        params.set('token', token);
+        return `${protocol}//${window.location.host}/ws?${params.toString()}`;
+      }
+
+      async function connectWebSocket() {
+        updateConnectionStatus(false, 'Authenticating...');
+
+        let token;
+        try {
+          token = await fetchAuthToken();
+        } catch (error) {
+          console.error('Authentication failed:', error);
+          updateConnectionStatus(false, 'Auth error');
+          setTimeout(connectWebSocket, 3000);
+          return;
+        }
+
+        updateConnectionStatus(false, 'Connecting...');
+        ws = new WebSocket(buildWebSocketUrl(token));
 
         ws.onopen = () => {
           console.log('WebSocket connected');
@@ -209,7 +242,7 @@
 
         ws.onerror = (error) => {
           console.error('WebSocket error:', error);
-          updateConnectionStatus(false);
+          updateConnectionStatus(false, 'Error');
         };
 
         ws.onclose = () => {
@@ -225,16 +258,16 @@
         };
       }
 
-      function updateConnectionStatus(connected) {
+      function updateConnectionStatus(connected, message) {
         const dot = document.getElementById('connection-dot');
         const text = document.getElementById('connection-text');
 
         if (connected) {
           dot.classList.add('connected');
-          text.textContent = 'Connected';
+          text.textContent = message || 'Connected';
         } else {
           dot.classList.remove('connected');
-          text.textContent = 'Disconnected';
+          text.textContent = message || 'Disconnected';
         }
       }
 

--- a/lib/demo-auth.test.ts
+++ b/lib/demo-auth.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  createAuthConfig,
+  generateSessionToken,
+  validateTokenRequest,
+  validateWebSocketRequest,
+} from '../demo/bin/auth.js';
+
+const TOKEN = '0123456789abcdef0123456789abcdef';
+
+function testConfig(options = {}) {
+  return createAuthConfig({ env: {}, token: TOKEN, ...options });
+}
+
+describe('demo auth helper', () => {
+  test('generates non-empty unique session tokens', () => {
+    const first = generateSessionToken();
+    const second = generateSessionToken();
+
+    expect(first.length).toBeGreaterThanOrEqual(32);
+    expect(second.length).toBeGreaterThanOrEqual(32);
+    expect(first).not.toBe(second);
+  });
+
+  test('accepts valid loopback host, matching origin, and token for websocket', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: '127.0.0.1:8080',
+      origin: 'http://127.0.0.1:8080',
+      token: TOKEN,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects missing websocket token', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: 'localhost:8080',
+      origin: 'http://localhost:8080',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  test('rejects invalid websocket token', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: 'localhost:8080',
+      origin: 'http://localhost:8080',
+      token: 'invalid-token',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  test('rejects different-length tokens without throwing', () => {
+    expect(() =>
+      validateWebSocketRequest(testConfig(), {
+        host: 'localhost:8080',
+        origin: 'http://localhost:8080',
+        token: 'short',
+      })
+    ).not.toThrow();
+
+    const result = validateWebSocketRequest(testConfig(), {
+      host: 'localhost:8080',
+      origin: 'http://localhost:8080',
+      token: 'short',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  test('rejects foreign websocket origin even with a valid token', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: '127.0.0.1:8080',
+      origin: 'https://evil.example',
+      token: TOKEN,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  test('rejects missing websocket origin', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: '127.0.0.1:8080',
+      token: TOKEN,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  test('rejects malformed websocket origin', () => {
+    const result = validateWebSocketRequest(testConfig(), {
+      host: '127.0.0.1:8080',
+      origin: 'not an origin',
+      token: TOKEN,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+  });
+
+  test('rejects missing hosts for token and websocket requests', () => {
+    const tokenResult = validateTokenRequest(testConfig(), {});
+    const wsResult = validateWebSocketRequest(testConfig(), {
+      origin: 'http://127.0.0.1:8080',
+      token: TOKEN,
+    });
+
+    expect(tokenResult.ok).toBe(false);
+    expect(tokenResult.status).toBe(400);
+    expect(wsResult.ok).toBe(false);
+    expect(wsResult.status).toBe(400);
+  });
+
+  test('rejects malformed hosts for token and websocket requests', () => {
+    const tokenResult = validateTokenRequest(testConfig(), { host: 'bad host:8080' });
+    const wsResult = validateWebSocketRequest(testConfig(), {
+      host: 'bad host:8080',
+      origin: 'http://bad host:8080',
+      token: TOKEN,
+    });
+
+    expect(tokenResult.ok).toBe(false);
+    expect(tokenResult.status).toBe(400);
+    expect(wsResult.ok).toBe(false);
+    expect(wsResult.status).toBe(400);
+  });
+
+  test('rejects unallowed hosts for token and websocket requests', () => {
+    const tokenResult = validateTokenRequest(testConfig(), { host: 'evil.example:8080' });
+    const wsResult = validateWebSocketRequest(testConfig(), {
+      host: 'evil.example:8080',
+      origin: 'http://evil.example:8080',
+      token: TOKEN,
+    });
+
+    expect(tokenResult.ok).toBe(false);
+    expect(tokenResult.status).toBe(403);
+    expect(wsResult.ok).toBe(false);
+    expect(wsResult.status).toBe(403);
+  });
+
+  test('allows token requests from an allowed host with no origin', () => {
+    const result = validateTokenRequest(testConfig(), { host: 'localhost:8080' });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects token requests with a foreign origin', () => {
+    const result = validateTokenRequest(testConfig(), {
+      host: 'localhost:8080',
+      origin: 'http://evil.example:8080',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  test('allows extra hosts only when explicitly configured', () => {
+    const defaultResult = validateTokenRequest(testConfig(), { host: 'demo.example:8080' });
+    const configured = testConfig({ allowedHosts: ['demo.example'] });
+    const tokenResult = validateTokenRequest(configured, { host: 'demo.example:8080' });
+    const wsResult = validateWebSocketRequest(configured, {
+      host: 'demo.example:8080',
+      origin: 'http://demo.example:8080',
+      token: TOKEN,
+    });
+
+    expect(defaultResult.ok).toBe(false);
+    expect(defaultResult.status).toBe(403);
+    expect(tokenResult.ok).toBe(true);
+    expect(wsResult.ok).toBe(true);
+  });
+
+  test('allows hosts configured through GHOSTTY_ALLOWED_HOSTS when using a wildcard bind', () => {
+    const wildcard = testConfig({ env: { HOST: '0.0.0.0' } });
+    const configured = testConfig({
+      env: { HOST: '0.0.0.0', GHOSTTY_ALLOWED_HOSTS: 'demo.example' },
+    });
+
+    expect(validateTokenRequest(wildcard, { host: 'demo.example:8080' }).ok).toBe(false);
+    expect(validateTokenRequest(configured, { host: 'demo.example:8080' }).ok).toBe(true);
+  });
+
+  test('allows a concrete HOST bind value as an allowed host', () => {
+    const configured = testConfig({ env: { HOST: 'demo.local' } });
+
+    const result = validateWebSocketRequest(configured, {
+      host: 'demo.local:8080',
+      origin: 'http://demo.local:8080',
+      token: TOKEN,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a small demo auth helper that generates a per-run token, validates allowed `Host` values, matches WebSocket `Origin` to the request host, and compares tokens safely.
- Require the token and origin/host checks before `/ws` upgrades in both static and Vite dev demo modes, and bind the demo to `127.0.0.1` by default.
- Update the demo clients and docs to fetch `/api/token` before connecting and document explicit `HOST` / `GHOSTTY_ALLOWED_HOSTS` remote-access configuration.

Fixes #160.

## Validation

- `bun install --frozen-lockfile`
- `bun test lib/demo-auth.test.ts`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `MISE_ZIG_VERSION=0.15.2 bun run build`
- `bun test` (347 pass, 0 fail)
- Production auth smoke against `PORT=18082 node demo/bin/demo.js`: verified `/api/token` headers/no CORS, unallowed `Host` rejection, missing-token WebSocket rejection, foreign-origin WebSocket rejection, and same-origin token-authenticated WebSocket success.

## Dogfooding

- Started the production demo server on `127.0.0.1:18082`.
- Opened the demo in agent-browser, captured an annotated screenshot of the loaded authenticated terminal page, recorded a short terminal interaction, and captured a post-command screenshot.
- Local evidence paths from this workspace:
  - `/tmp/ghostty-web-issue-160-dogfood/screenshots/01-demo-loaded.png`
  - `/tmp/ghostty-web-issue-160-dogfood/screenshots/02-terminal-command.png`
  - `/tmp/ghostty-web-issue-160-dogfood/videos/terminal-authenticated-session.webm`

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: GitHub issue coder/ghostty-web#160

## Issue and scope

**Issue:** `coder/ghostty-web#160` — `[Security] Remote Code Execution via unauthenticated WebSocket terminal input`.

**Live issue state checked:** `gh issue view 160 --repo coder/ghostty-web --comments --json ...` on June 26, 2026. The issue is open and labeled `triage:done`, `bug`, and `accepted`. The issue report and triage comment confirm that the demo WebSocket endpoint `/ws` accepts terminal input without authentication or browser-origin validation, letting a malicious page on another origin connect to a local PTY-backed shell and write commands.

**In scope for this plan:** secure the demo PTY WebSocket flow so unauthenticated and cross-origin browser requests cannot receive the terminal welcome banner, spawn a PTY, or send shell input. Keep the implementation minimal and reviewable.

**Out of scope:** package publishing, repository security-setting changes such as enabling private vulnerability reporting, unrelated renderer/parser changes, broad demo refactors, and unrelated static-file hardening unless directly needed by this fix. During planning, explorers flagged a possible `/dist/` path traversal in `demo/bin/demo.js`; I searched existing issues for traversal/dist-path reports and found no matching issue besides #160. A quick URL parser check did not verify the simple `../` traversal claim, so this plan does **not** treat it as a confirmed bug and does not include it. If implementation later verifies a real out-of-scope bug with reproducible evidence, follow the user's out-of-scope procedure: search existing issues again, comment on a match or create a new `needs-triage` issue with evidence, then return to #160.

## Verified repository context

- `demo/bin/demo.js` is the main demo server script. It serves static production HTML, starts a PTY through `@lydell/node-pty`, and owns the production WebSocket upgrade handler.
- `demo/bin/demo.js` production upgrade path currently upgrades every `/ws` request with `wss.handleUpgrade(...)` before any authentication or `Origin`/`Host` checks, then `wss.on('connection')` creates the PTY and forwards WebSocket messages to `ptyProcess.write(...)`.
- `demo/bin/demo.js --dev` creates a Vite server and uses `vite.httpServer.prependListener('upgrade', ...)` to intercept `/ws`; this path also forwards directly to `wss.handleUpgrade(...)` without validation.
- There are two browser clients to update:
  - The inline `HTML_TEMPLATE` inside `demo/bin/demo.js` for production/static mode.
  - `demo/index.html` for Vite dev mode.
- Current clients build `/ws?cols=<cols>&rows=<rows>` with no session token.
- Root scripts include `bun run demo` and `bun run demo:dev`; the demo package has its own dependencies under `demo/package.json`. Existing automated tests are focused under `lib/`; there are no committed demo-server security tests yet.

## Recommended design

Implement three defenses together:

1. **Per-process WebSocket session token** — generate an unguessable token when the demo server starts. Same-origin demo pages fetch it from a local endpoint and append it to `/ws` as a query parameter. `/ws` rejects missing or incorrect tokens before `wss.handleUpgrade(...)` and before PTY creation.
2. **Strict `Host` and `Origin` validation** — reject DNS-rebinding-style and cross-origin requests. The token endpoint and WebSocket endpoint should only serve allowed hostnames, and `/ws` should require a browser `Origin` that matches the request `Host`.
3. **Loopback-only bind by default** — bind to `127.0.0.1` unless the user explicitly opts into another `HOST`, preserving local-demo ergonomics while avoiding LAN exposure by default.

This is stronger than an `Origin` check alone and avoids printing a token in the initial browser URL. The token endpoint relies on same-origin policy and server-side host/origin checks rather than permissive CORS.

## Implementation phases

### Phase 1 — Add a small, testable auth helper

Create a side-effect-free helper module in the demo package, for example `demo/bin/auth.js`, so the security logic can be unit-tested without importing `demo/bin/demo.js` and accidentally starting the PTY server.

Helper responsibilities:

- Generate a per-process token with Node crypto, e.g. `randomBytes(32).toString('base64url')` or an equivalent high-entropy representation.
- Build an auth config containing:
  - `token`.
  - `bindHost`, defaulting to `process.env.HOST || '127.0.0.1'`.
  - Built-in allowed hostnames: `localhost`, `127.0.0.1`, and `::1`.
  - Optional explicit extra hostnames from a documented env var such as `GHOSTTY_ALLOWED_HOSTS=host1,host2`.
  - If `HOST` is set to a concrete non-wildcard hostname/IP, include it in the allowed set. If `HOST=0.0.0.0` or `HOST=::`, do **not** automatically allow arbitrary incoming hosts; require `GHOSTTY_ALLOWED_HOSTS` for remote access.
- Validate `Host` headers after parsing out the port. Reject missing, malformed, or unallowed hosts.
- Validate `Origin` headers:
  - For `/ws`, require an `Origin` header, require it to parse cleanly, and require its host/port to match the request `Host`.
  - For `/api/token`, allow same-origin browser GETs that may omit `Origin`, but if `Origin` is present, require it to match the request `Host`.
- Validate `/ws` query token exactly. Use length checks and `crypto.timingSafeEqual` or an equivalent safe comparison that cannot throw on different lengths.
- Return structured decisions, e.g. `{ ok: true }` or `{ ok: false, status: 401, reason: 'Unauthorized' }`, so `demo/bin/demo.js` can write precise HTTP errors and tests can assert decisions.
- Add defensive assertions for impossible internal configuration mistakes, such as an empty generated token or empty built-in host allowlist. External malformed requests should be rejected with HTTP decisions, not assertions.

Keep this helper narrow; avoid general auth framework abstractions or insecure opt-out flags.

### Phase 2 — Integrate auth into `demo/bin/demo.js`

Update `demo/bin/demo.js` surgically:

1. Import the auth helper and create one auth config/session token at startup.
2. Introduce `HOST = process.env.HOST || '127.0.0.1'` and use it in both startup modes:
   - Production/static mode: `httpServer.listen(HTTP_PORT, HOST, ...)`.
   - Dev mode: Vite `server: { host: HOST, port: HTTP_PORT, strictPort: true, cors: false }`, or otherwise ensure Vite cannot add permissive CORS headers to `/api/token`.
3. Add a production HTTP route for `GET /api/token` before static-file handling:
   - Validate `Host` and any present `Origin` using the helper.
   - Return `403`/`400` for invalid requests.
   - On success, return `JSON.stringify({ token })` with headers:
     - `Content-Type: application/json`
     - `Cache-Control: no-store`
     - `X-Content-Type-Options: nosniff`
   - Do **not** set `Access-Control-Allow-Origin`.
4. Add equivalent Vite dev middleware for `/api/token` before `await vite.listen()` so Vite's static/fallback handling cannot intercept it. Confirm this dev-mode response also omits `Access-Control-Allow-Origin`; if Vite would add permissive CORS globally, disable it for this server or remove it for `/api/token`.
5. In the production `httpServer.on('upgrade')` path, validate `/ws` before `wss.handleUpgrade(...)`:
   - Non-`/ws` upgrades should still be destroyed/passed as they are today.
   - Missing/invalid token should return `401 Unauthorized` and destroy the socket.
   - Missing/malformed/foreign `Origin` or unallowed `Host` should return `403 Forbidden` or `400 Bad Request` and destroy the socket.
   - Rejected upgrades must not emit `connection`, call `createPtySession`, or write the `Welcome to ghostty-web!` banner.
6. Apply the same validation in the Vite `prependListener('upgrade', ...)` path before `wss.handleUpgrade(...)`.
7. Update startup banner text to show the bound URL and explain that the WebSocket is protected by a per-run same-origin token. Do not print the token itself. If `HOST` is wildcard/non-loopback, print a conspicuous warning that remote access requires explicit allowed hosts and exposes a local shell if misconfigured.

### Phase 3 — Update both browser clients

Update the production inline `HTML_TEMPLATE` in `demo/bin/demo.js` and the dev page `demo/index.html`.

Required client behavior:

1. Before each WebSocket connection attempt, fetch `/api/token` from the same origin.
2. If token fetch fails, set the visible connection status to an authentication/error state and retry on the existing reconnect cadence without opening `/ws` unauthenticated.
3. Build the WebSocket URL with existing size parameters plus `token`, e.g. `/ws?cols=<cols>&rows=<rows>&token=<encoded token>`.
4. Preserve existing terminal input forwarding, resize messages, status updates, and reconnect behavior.
5. In the inline `HTML_TEMPLATE` backtick string, avoid accidental server-side `${...}` interpolation. Prefer string concatenation or escape client-side template-literal placeholders carefully.

### Phase 4 — Add automated tests without introducing flaky PTY dependencies

Add focused unit tests for the helper, e.g. `lib/demo-auth.test.ts`, importing `../demo/bin/auth.js`. Keep these tests independent of `@lydell/node-pty`, Vite, and a live shell.

Test cases should cover at least:

- Token generation returns a non-empty high-entropy-looking token and successive generated tokens differ.
- Valid loopback `Host` and matching `Origin` plus correct token are accepted for `/ws`.
- Missing token is rejected with `401`.
- Invalid token is rejected with `401`.
- Token comparison with a different-length token rejects cleanly and does not throw.
- Foreign `Origin` is rejected even when the token is valid.
- Missing or malformed `Origin` is rejected for `/ws`.
- Missing, malformed, or unallowed `Host` is rejected for both `/api/token` and `/ws`.
- `/api/token` allows an allowed `Host` with no `Origin` but rejects a foreign `Origin` if present.
- Extra allowed hosts only work when explicitly configured through the helper/config.

Do not add a default CI test that spawns the full PTY demo server unless the implementation also makes demo dependencies reliable in the root test environment. Use manual/optional smoke scripts for live PTY behavior instead.

### Phase 5 — Documentation updates

Update only documentation that is directly affected by the security behavior:

- Root `README.md` and/or `demo/README.md` sections that mention `npx @ghostty-web/demo@next`, `bun run demo`, or `bun run demo:dev`.
- Document that the demo now:
  - Binds to `127.0.0.1` by default.
  - Uses a per-run same-origin token for `/ws`.
  - Rejects cross-origin WebSocket handshakes.
  - Supports `HOST=<host>` for explicit bind changes.
  - Requires `GHOSTTY_ALLOWED_HOSTS` when intentionally serving through additional hostnames or wildcard binds.
- Keep the warning concise: this demo starts a real local shell; remote exposure should be avoided unless the user understands the risk.

Do not update broad architecture docs or stale unrelated paths unless the touched instructions would become misleading for #160 verification.

## Acceptance criteria

- Starting the demo with no env overrides binds only to loopback (`127.0.0.1:<port>`), not all interfaces.
- `GET /api/token` returns a token only for allowed `Host` values, sets `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`, and does not include `Access-Control-Allow-Origin` in either production/static mode or Vite dev mode.
- `GET /api/token` rejects an unallowed `Host`, for example `Host: evil.example:<port>`, without returning the token.
- `/ws` rejects missing or invalid tokens before `wss.handleUpgrade(...)` and before PTY creation.
- `/ws` rejects foreign, malformed, or missing browser `Origin` values even if a token is present.
- A valid same-origin browser flow works in both production/static mode and Vite dev mode.
- Unauthorized or cross-origin WebSocket attempts do not receive `Welcome to ghostty-web!`, do not create a marker file through shell input, and do not spawn a PTY session.
- Existing terminal behavior still works for the authorized demo page: shell output, user input, resize messages, reconnect behavior, and cleanup on close.
- Automated helper tests cover token, host, and origin decisions and pass under `bun test`.
- Formatting, lint, typecheck, tests, and build pass before completion, or any environmental blocker is reported with exact commands and errors.

## Validation and quality gates

Run these during implementation, fixing failures before claiming success:

1. **Focused unit tests**
   ```bash
   bun test lib/demo-auth.test.ts
   ```

2. **Full repository checks**
   ```bash
   bun run fmt && bun run lint && bun run typecheck && bun test && bun run build
   ```

3. **Demo dependency setup for live smoke tests**
   ```bash
   cd demo
   bun install --frozen-lockfile
   cd ..
   ```

4. **Production/static smoke test**
   ```bash
   bun run build
   PORT=18080 node demo/bin/demo.js
   ```
   In another terminal, verify:
   ```bash
   # Token endpoint accepts allowed Host and has no permissive CORS.
   curl -i http://127.0.0.1:18080/api/token

   # Host allowlist blocks DNS-rebinding-style Host headers.
   curl -i -H 'Host: evil.example:18080' http://127.0.0.1:18080/api/token

   # No unauthenticated websocket should upgrade or receive the banner.
   node --input-type=module - <<'NODE'
   // Paste a short smoke client here, or use a checked-in/temporary script such as:
   // node ./scripts/auth-smoke.mjs
   NODE
   ```
   The Node smoke client should test: missing token, invalid token, valid token with `Origin: https://evil.example`, and valid token with `Origin: http://127.0.0.1:18080`.

5. **Dev/Vite smoke test**
   ```bash
   PORT=18081 bun run demo:dev
   ```
   Verify the same `/api/token` and `/ws` behavior against `http://127.0.0.1:18081/demo/`.

## Dogfooding plan and reviewable evidence

Because this change affects an interactive browser terminal, dogfooding must produce visual artifacts a reviewer can inspect.

1. **Authorized terminal success evidence**
   - Start the demo in dev mode or production mode after the build.
   - Use browser automation (the `agent-browser` skill/tooling is appropriate in an Exec-mode implementation workspace) to open the printed loopback URL.
   - Confirm the terminal connects, shows the welcome banner, and can run a harmless command such as:
     ```bash
     echo ghostty-web-160-ok
     whoami
     ```
   - Capture a screenshot named/described like `issue-160-authorized-terminal.png` showing the connected terminal and harmless command output.
   - Capture a short recording, e.g. `issue-160-authorized-terminal.webm`, showing page load, token fetch, WebSocket connect, and command execution.

2. **Network/security evidence**
   - Capture a browser DevTools/network screenshot or equivalent browser automation snapshot showing:
     - `/api/token` returns `200` with `Cache-Control: no-store` and no `Access-Control-Allow-Origin` header.
     - `/ws?...token=<redacted>` upgrades only after the token fetch. Redact or avoid exposing the token in the artifact.
   - Save as `issue-160-network-token.png` or include equivalent sanitized logs.

3. **Cross-origin attack blocked evidence**
   - Serve a tiny attacker page from a different local origin, for example `http://127.0.0.1:19082`, that attempts:
     - `fetch('http://127.0.0.1:18080/api/token')` and logs the CORS failure / unreadable response.
     - `new WebSocket('ws://127.0.0.1:18080/ws?cols=80&rows=24')` without a token.
     - Optional Node smoke (not browser JS) for `Origin: https://evil.example` with a valid token, proving the server rejects foreign origins even if the token is known.
   - Capture a screenshot `issue-160-cross-origin-blocked.png` and a short recording `issue-160-cross-origin-blocked.webm` showing the blocked attempts.
   - If using a harmless marker-file PoC, verify and record that the marker file is not created.

4. **Loopback bind evidence**
   - Capture terminal output from `ss -ltnp | grep 18080` or `lsof -iTCP:18080 -sTCP:LISTEN` showing the default listener is `127.0.0.1:<port>`.
   - Include this text in the PR description; a screenshot is useful if collected alongside the browser artifacts.

## Minimal PR shape

Expected touched files:

- `demo/bin/auth.js` (new helper) or equivalent small helper colocated under `demo/bin/`.
- `demo/bin/demo.js` (server integration, token endpoint, host/origin/token validation, client template update, bind host).
- `demo/index.html` (dev client token fetch and WebSocket URL update).
- `lib/demo-auth.test.ts` (focused helper tests).
- `README.md` and/or `demo/README.md` (only directly relevant demo security notes).

Avoid unrelated cleanup and avoid carrying over an unverified static-file traversal fix into this PR.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
