### PR TITLE
fix: stabilize WASM viewport row reads

### DIFF
--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -292,7 +292,7 @@ export class GhosttyTerminal {
         const view = new DataView(this.memory.buffer);
         let offset = configPtr;
 
-        // scrollback_limit (u32)
+        // scrollback_limit (u32) - line count; the WASM wrapper converts it to bytes
         view.setUint32(offset, config.scrollbackLimit ?? 10000, true);
         offset += 4;
 
@@ -443,7 +443,9 @@ export class GhosttyTerminal {
    * Get ALL viewport cells in ONE WASM call - the key performance optimization!
    * Returns a reusable cell array (zero allocation after warmup).
    */
-  getViewport(): GhosttyCell[] {
+  getViewport(refreshRenderState = true): GhosttyCell[] {
+    if (refreshRenderState) this.update();
+
     const totalCells = this._cols * this._rows;
     const neededSize = totalCells * GhosttyTerminal.CELL_SIZE;
 
@@ -484,7 +486,7 @@ export class GhosttyTerminal {
     // Call update() to ensure render state is fresh.
     // This is safe to call multiple times - dirty state persists until markClean().
     this.update();
-    const viewport = this.getViewport();
+    const viewport = this.getViewport(false);
     const start = y * this._cols;
     // Return deep copies to avoid cell pool reference issues
     return viewport.slice(start, start + this._cols).map((cell) => ({ ...cell }));
@@ -799,12 +801,15 @@ export class GhosttyTerminal {
    * (Hindi, emoji with ZWJ, etc.) it returns multiple codepoints.
    * @returns Array of codepoints, or null on error
    */
-  getGrapheme(row: number, col: number): number[] | null {
+  getGrapheme(row: number, col: number, refreshRenderState = true): number[] | null {
     // Allocate buffer on first use (16 codepoints should be enough for any grapheme)
     if (!this.graphemeBuffer) {
       this.graphemeBufferPtr = this.exports.ghostty_wasm_alloc_u8_array(16 * 4);
       this.graphemeBuffer = new Uint32Array(this.memory.buffer, this.graphemeBufferPtr, 16);
     }
+
+    // Grapheme lookup reads from the RenderState row cache.
+    if (refreshRenderState) this.update();
 
     const count = this.exports.ghostty_render_state_get_grapheme(
       this.handle,
@@ -825,8 +830,8 @@ export class GhosttyTerminal {
    * Get a string representation of the grapheme at the given position.
    * This properly handles complex scripts like Hindi, emoji with ZWJ, etc.
    */
-  getGraphemeString(row: number, col: number): string {
-    const codepoints = this.getGrapheme(row, col);
+  getGraphemeString(row: number, col: number, refreshRenderState = true): string {
+    const codepoints = this.getGrapheme(row, col, refreshRenderState);
     if (!codepoints || codepoints.length === 0) return ' ';
     return String.fromCodePoint(...codepoints);
   }

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -29,7 +29,7 @@ export interface IRenderable {
    * For cells with grapheme_len > 0, this returns all codepoints combined.
    * For simple cells, returns the single character.
    */
-  getGraphemeString?(row: number, col: number): string;
+  getGraphemeString?(row: number, col: number, refreshRenderState?: boolean): string;
 }
 
 export interface IScrollbackProvider {
@@ -641,8 +641,9 @@ export class CanvasRenderer {
     // Get the character to render - use grapheme lookup for complex scripts
     let char: string;
     if (cell.grapheme_len > 0 && this.currentBuffer?.getGraphemeString) {
-      // Cell has additional codepoints - get full grapheme cluster
-      char = this.currentBuffer.getGraphemeString(y, x);
+      // Cell has additional codepoints - get full grapheme cluster.
+      // Line fetches already refreshed the render state; avoid per-cell refreshes.
+      char = this.currentBuffer.getGraphemeString(y, x, false);
     } else {
       // Simple cell - single codepoint
       char = String.fromCodePoint(cell.codepoint || 32); // Default to space if null

--- a/lib/terminal.test.ts
+++ b/lib/terminal.test.ts
@@ -79,6 +79,45 @@ function expectEchoRender(
   expect(renderArgs[0][1]).toBe(false);
 }
 
+const ISSUE_139_ESC = '\x1b';
+
+function cellsToTrimmedText(cells: Array<{ codepoint: number; width?: number }>): string {
+  let text = '';
+  for (const cell of cells) {
+    if (cell.width === 0) continue;
+    text += String.fromCodePoint(cell.codepoint || 32);
+  }
+  return text.trimEnd();
+}
+
+function viewportRowsToText(term: Terminal): string[] {
+  const viewport = term.wasmTerm!.getViewport();
+  const rows: string[] = [];
+  for (let row = 0; row < term.rows; row++) {
+    const start = row * term.cols;
+    rows.push(cellsToTrimmedText(viewport.slice(start, start + term.cols)));
+  }
+  return rows;
+}
+
+function buildIssue139MarkerBatch(rep: number, firstLine: number, markers: string[]): string {
+  const parts: string[] = [];
+  for (let line = 1; line <= 68; line++) {
+    const index = firstLine + line - 1;
+    const marker = `rep=${String(rep).padStart(2, '0')} line=${String(line).padStart(
+      3,
+      '0'
+    )} marker=${String(index).padStart(4, '0')} ${'#'.repeat(52)}`;
+    parts.push(
+      `${markers.length === 0 ? '' : '\r\n'}${ISSUE_139_ESC}[1;3;38;5;${
+        (rep * 17 + line) % 256
+      }m${marker}${ISSUE_139_ESC}[0m`
+    );
+    markers.push(marker);
+  }
+  return parts.join('');
+}
+
 describe('Terminal', () => {
   let container: HTMLElement;
 
@@ -1433,6 +1472,49 @@ describe('Buffer Access API', () => {
 });
 
 describe('Terminal Config', () => {
+  test('keeps viewport coherent and treats scrollback as a line budget across page-boundary output', async () => {
+    if (typeof document === 'undefined') return;
+
+    const term = await createIsolatedTerminal({ cols: 130, rows: 39, scrollback: 10000 });
+    const container = document.createElement('div');
+    term.open(container);
+
+    try {
+      const markers: string[] = [];
+      let previousScrollbackLength = 0;
+      let scrollbackDrop: { rep: number; before: number; after: number } | undefined;
+
+      for (let rep = 1; rep <= 14; rep++) {
+        term.write(buildIssue139MarkerBatch(rep, markers.length, markers));
+        term.wasmTerm!.update();
+
+        const scrollbackLength = term.wasmTerm!.getScrollbackLength();
+        if (scrollbackLength < previousScrollbackLength) {
+          scrollbackDrop ??= {
+            rep,
+            before: previousScrollbackLength,
+            after: scrollbackLength,
+          };
+        }
+        previousScrollbackLength = scrollbackLength;
+      }
+
+      const expectedRows = markers.slice(-term.rows);
+      expect(viewportRowsToText(term)).toEqual(expectedRows);
+
+      for (const row of [0, Math.floor(term.rows / 2), term.rows - 1]) {
+        const line = term.wasmTerm!.getLine(row);
+        expect(line).not.toBeNull();
+        expect(cellsToTrimmedText(line!)).toBe(expectedRows[row]);
+      }
+
+      expect(scrollbackDrop).toBeUndefined();
+      expect(previousScrollbackLength).toBeGreaterThanOrEqual(markers.length - term.rows);
+    } finally {
+      term.dispose();
+    }
+  });
+
   test('should pass scrollback option to WASM terminal', async () => {
     if (typeof document === 'undefined') return;
 
@@ -2834,6 +2916,7 @@ describe('Grapheme Cluster Support', () => {
     term.open(container!);
     term.write('Hello');
 
+    term.wasmTerm!.update();
     // Get the viewport and check the first cell
     const viewport = term.wasmTerm!.getViewport();
     expect(viewport[0].codepoint).toBe(0x48); // 'H'

--- a/patches/ghostty-wasm-api.patch
+++ b/patches/ghostty-wasm-api.patch
@@ -437,10 +437,10 @@ index bc92597f5..d0ee49c1b 100644
      _ = @import("../../lib/allocator.zig");
 diff --git a/src/terminal/c/terminal.zig b/src/terminal/c/terminal.zig
 new file mode 100644
-index 000000000..73ae2e6fa
+index 000000000..3a70fe5e4
 --- /dev/null
 +++ b/src/terminal/c/terminal.zig
-@@ -0,0 +1,1123 @@
+@@ -0,0 +1,1122 @@
 +//! C API wrapper for Terminal
 +//!
 +//! This provides a minimal, high-performance interface to Ghostty's Terminal
@@ -471,6 +471,8 @@ index 000000000..73ae2e6fa
 +const point = @import("../point.zig");
 +const Style = @import("../style.zig").Style;
 +const device_status = @import("../device_status.zig");
++const pagepkg = @import("../page.zig");
++const Page = pagepkg.Page;
 +
 +const log = std.log.scoped(.terminal_c);
 +
@@ -821,11 +823,21 @@ index 000000000..73ae2e6fa
 +
 +    const wrapper = alloc.create(TerminalWrapper) catch return null;
 +
-+    // Parse config or use defaults
-+    const scrollback_limit: usize = if (config_) |cfg|
++    // scrollback_limit comes from JS as a line count; Terminal.init expects bytes.
++    const scrollback_lines: usize = if (config_) |cfg|
 +        if (cfg.scrollback_limit == 0) std.math.maxInt(usize) else cfg.scrollback_limit
 +    else
 +        10_000;
++
++    const scrollback_limit: usize = if (scrollback_lines == std.math.maxInt(usize))
++        std.math.maxInt(usize)
++    else blk: {
++        const cap = pagepkg.std_capacity.adjust(.{ .cols = @intCast(cols) }) catch
++            break :blk std.math.mul(usize, scrollback_lines, 1024) catch std.math.maxInt(usize);
++        const page_size = Page.layout(cap).total_size;
++        const bytes_per_line = page_size / cap.rows;
++        break :blk std.math.mul(usize, scrollback_lines, bytes_per_line) catch std.math.maxInt(usize);
++    };
 +
 +    // Setup terminal colors
 +    var colors = Terminal.Colors.default;
@@ -935,26 +947,26 @@ index 000000000..73ae2e6fa
 +/// Returns dirty state: 0=none, 1=partial, 2=full
 +pub fn renderStateUpdate(ptr: ?*anyopaque) callconv(.c) GhosttyDirty {
 +    const wrapper: *TerminalWrapper = @ptrCast(@alignCast(ptr orelse return .full));
-+    
++
 +    // Detect screen buffer switch (normal <-> alternate)
 +    const current_is_alternate = wrapper.terminal.screens.active_key == .alternate;
 +    const screen_switched = current_is_alternate != wrapper.last_screen_is_alternate;
 +    wrapper.last_screen_is_alternate = current_is_alternate;
-+    
++
 +    // When screen switches, we must fully reset the render state to avoid
 +    // stale cached cell data from the previous screen buffer.
 +    if (screen_switched) {
 +        wrapper.render_state.deinit(wrapper.alloc);
 +        wrapper.render_state = RenderState.empty;
 +    }
-+    
++
 +    wrapper.render_state.update(wrapper.alloc, &wrapper.terminal) catch return .full;
-+    
++
 +    // If screen switched, always return full dirty to force complete redraw
 +    if (screen_switched) {
 +        return .full;
 +    }
-+    
++
 +    return switch (wrapper.render_state.dirty) {
 +        .false => .none,
 +        .partial => .partial,
@@ -979,7 +991,7 @@ index 000000000..73ae2e6fa
 +    return @intCast(wrapper.render_state.cursor.active.x);
 +}
 +
-+/// Get cursor Y position  
++/// Get cursor Y position
 +pub fn renderStateGetCursorY(ptr: ?*anyopaque) callconv(.c) c_int {
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return 0));
 +    return @intCast(wrapper.render_state.cursor.active.y);
@@ -1022,8 +1034,9 @@ index 000000000..73ae2e6fa
 +    @memset(wrapper.render_state.row_data.items(.dirty), false);
 +}
 +
-+/// Get ALL viewport cells in one call - reads directly from terminal screen buffer.
-+/// This bypasses the RenderState cache to ensure fresh data for all rows.
++/// Get ALL viewport cells in one call from RenderState's cached row data.
++/// The cache is built by renderStateUpdate and matches the native renderer's
++/// coherent row mapping across page boundaries.
 +/// Returns total cells written (rows * cols), or -1 on error.
 +pub fn renderStateGetViewport(
 +    ptr: ?*anyopaque,
@@ -1032,69 +1045,57 @@ index 000000000..73ae2e6fa
 +) callconv(.c) c_int {
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return -1));
 +    const rs = &wrapper.render_state;
-+    const t = &wrapper.terminal;
 +    const rows = rs.rows;
 +    const cols = rs.cols;
 +    const total: usize = @as(usize, rows) * cols;
 +
 +    if (buf_size < total) return -1;
 +
-+    // Read directly from terminal's active screen, bypassing RenderState cache.
-+    // This ensures we always get fresh data for ALL rows, not just dirty ones.
-+    const pages = &t.screens.active.pages;
++    const default_cell: GhosttyCell = .{
++        .codepoint = 0,
++        .fg_r = rs.colors.foreground.r,
++        .fg_g = rs.colors.foreground.g,
++        .fg_b = rs.colors.foreground.b,
++        .bg_r = rs.colors.background.r,
++        .bg_g = rs.colors.background.g,
++        .bg_b = rs.colors.background.b,
++        .flags = 0,
++        .width = 1,
++        .hyperlink_id = 0,
++    };
++
++    // Use the cached row data from RenderState, built during update(). This
++    // matches the native renderer and keeps rows coherent across page boundaries.
++    const row_data = rs.row_data.slice();
++    const row_pins = row_data.items(.pin);
++    const row_cells = row_data.items(.cells);
++    if (row_pins.len < rows or row_cells.len < rows) {
++        std.debug.assert(row_pins.len >= rows and row_cells.len >= rows);
++    }
 +
 +    var idx: usize = 0;
 +    for (0..rows) |y| {
-+        // Get the row from the active viewport
-+        const pin = pages.pin(.{ .active = .{ .y = @intCast(y) } }) orelse {
-+            // Row doesn't exist, fill with defaults
++        if (y >= row_pins.len or y >= row_cells.len or row_cells[y].len < cols) {
 +            for (0..cols) |_| {
-+                out[idx] = .{
-+                    .codepoint = 0,
-+                    .fg_r = rs.colors.foreground.r,
-+                    .fg_g = rs.colors.foreground.g,
-+                    .fg_b = rs.colors.foreground.b,
-+                    .bg_r = rs.colors.background.r,
-+                    .bg_g = rs.colors.background.g,
-+                    .bg_b = rs.colors.background.b,
-+                    .flags = 0,
-+                    .width = 1,
-+                    .hyperlink_id = 0,
-+                };
++                out[idx] = default_cell;
 +                idx += 1;
 +            }
 +            continue;
-+        };
++        }
 +
-+        const cells = pin.cells(.all);
-+        const page = pin.node.data;
++        const cells_slice = row_cells[y].slice();
++        const raw_cells = cells_slice.items(.raw);
++        const cached_graphemes = cells_slice.items(.grapheme);
++        const cached_styles = cells_slice.items(.style);
 +
 +        for (0..cols) |x| {
-+            if (x >= cells.len) {
-+                // Past end of row, fill with default
-+                out[idx] = .{
-+                    .codepoint = 0,
-+                    .fg_r = rs.colors.foreground.r,
-+                    .fg_g = rs.colors.foreground.g,
-+                    .fg_b = rs.colors.foreground.b,
-+                    .bg_r = rs.colors.background.r,
-+                    .bg_g = rs.colors.background.g,
-+                    .bg_b = rs.colors.background.b,
-+                    .flags = 0,
-+                    .width = 1,
-+                    .hyperlink_id = 0,
-+                };
-+                idx += 1;
-+                continue;
-+            }
++            const cell = &raw_cells[x];
 +
-+            const cell = &cells[x];
-+
-+            // Get style from page styles (cell has style_id)
-+            const sty: Style = if (cell.style_id > 0)
-+                page.styles.get(page.memory, cell.style_id).*
-+            else
-+                .{};
++            // Style data is cached only for cells that need non-default style data.
++            const sty: Style = switch (cell.content_tag) {
++                .bg_color_rgb, .bg_color_palette => .{},
++                else => if (cell.style_id > 0) cached_styles[x] else .{},
++            };
 +
 +            // Resolve colors
 +            const fg: color.RGB = switch (sty.fg_color) {
@@ -1117,7 +1118,7 @@ index 000000000..73ae2e6fa
 +
 +            // Get grapheme length if cell has grapheme data
 +            const grapheme_len: u8 = if (cell.hasGrapheme())
-+                if (page.lookupGrapheme(cell)) |cps| @min(@as(u8, @intCast(cps.len)), 255) else 0
++                @min(@as(u8, @intCast(cached_graphemes[x].len)), 255)
 +            else
 +                0;
 +
@@ -1157,38 +1158,36 @@ index 000000000..73ae2e6fa
 +) callconv(.c) c_int {
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return -1));
 +    const rs = &wrapper.render_state;
-+    const t = &wrapper.terminal;
++    const rows: usize = @intCast(rs.rows);
 +    const cols: usize = @intCast(rs.cols);
 +
 +    if (row < 0 or col < 0) return -1;
-+    if (@as(usize, @intCast(row)) >= rs.rows) return -1;
-+    if (@as(usize, @intCast(col)) >= cols) return -1;
++    const y: usize = @intCast(row);
++    const x: usize = @intCast(col);
++    if (y >= rows or x >= cols) return -1;
 +    if (buf_size < 1) return -1;
 +
-+    // Get the pin for this row from the terminal's active screen
-+    const pages = &t.screens.active.pages;
-+    const pin = pages.pin(.{ .active = .{ .y = @intCast(row) } }) orelse return -1;
++    // Use the same cached row/cell data as renderStateGetViewport so the
++    // primary cell and extra grapheme codepoints come from the same row map.
++    const row_data = rs.row_data.slice();
++    const row_cells = row_data.items(.cells);
++    if (y >= row_cells.len or row_cells[y].len <= x) return -1;
 +
-+    const cells = pin.cells(.all);
-+    const page = pin.node.data;
-+    const x: usize = @intCast(col);
-+
-+    if (x >= cells.len) return -1;
-+
-+    const cell = &cells[x];
++    const cells_slice = row_cells[y].slice();
++    const raw_cells = cells_slice.items(.raw);
++    const cached_graphemes = cells_slice.items(.grapheme);
++    const cell = &raw_cells[x];
 +
 +    // First codepoint is always from the cell
 +    out[0] = cell.codepoint();
 +    var count: usize = 1;
 +
-+    // Add extra codepoints from grapheme map if present
++    // Add extra codepoints from the cached grapheme slice if present.
 +    if (cell.hasGrapheme()) {
-+        if (page.lookupGrapheme(cell)) |cps| {
-+            for (cps) |cp| {
-+                if (count >= buf_size) break;
-+                out[count] = cp;
-+                count += 1;
-+            }
++        for (cached_graphemes[x]) |cp| {
++            if (count >= buf_size) break;
++            out[count] = cp;
++            count += 1;
 +        }
 +    }
 +
@@ -1207,8 +1206,8 @@ index 000000000..73ae2e6fa
 +pub fn hasMouseTracking(ptr: ?*anyopaque) callconv(.c) bool {
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return false));
 +    return wrapper.terminal.modes.get(.mouse_event_normal) or
-+           wrapper.terminal.modes.get(.mouse_event_button) or
-+           wrapper.terminal.modes.get(.mouse_event_any);
++        wrapper.terminal.modes.get(.mouse_event_button) or
++        wrapper.terminal.modes.get(.mouse_event_any);
 +}
 +
 +/// Query arbitrary terminal mode by number
@@ -1245,22 +1244,22 @@ index 000000000..73ae2e6fa
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return -1));
 +    const rs = &wrapper.render_state;
 +    const cols = rs.cols;
-+    
++
 +    if (buf_size < cols) return -1;
 +    if (offset < 0) return -1;
-+    
++
 +    const scrollback_len = getScrollbackLength(ptr);
 +    if (offset >= scrollback_len) return -1;
-+    
++
 +    // Get the pin for this scrollback row
 +    // history point: y=0 is oldest, y=scrollback_len-1 is newest
 +    const pages = &wrapper.terminal.screens.active.pages;
 +    const pin = pages.pin(.{ .history = .{ .y = @intCast(offset) } }) orelse return -1;
-+    
++
 +    // Get cells for this row
 +    const cells = pin.cells(.all);
 +    const page = pin.node.data;
-+    
++
 +    // Fill output buffer
 +    for (0..cols) |x| {
 +        if (x >= cells.len) {
@@ -1279,15 +1278,15 @@ index 000000000..73ae2e6fa
 +            };
 +            continue;
 +        }
-+        
++
 +        const cell = &cells[x];
-+        
++
 +        // Get style from page styles (cell has style_id)
 +        const sty: Style = if (cell.style_id > 0)
 +            page.styles.get(page.memory, cell.style_id).*
 +        else
 +            .{};
-+        
++
 +        // Resolve colors
 +        const fg: color.RGB = switch (sty.fg_color) {
 +            .none => rs.colors.foreground,
@@ -1295,7 +1294,7 @@ index 000000000..73ae2e6fa
 +            .rgb => |rgb| rgb,
 +        };
 +        const bg: color.RGB = if (sty.bg(cell, &rs.colors.palette)) |rgb| rgb else rs.colors.background;
-+        
++
 +        // Build flags
 +        var flags: u8 = 0;
 +        if (sty.flags.bold) flags |= 1 << 0;
@@ -1391,11 +1390,11 @@ index 000000000..73ae2e6fa
 +pub fn isRowWrapped(ptr: ?*anyopaque, y: c_int) callconv(.c) bool {
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return false));
 +    const pages = &wrapper.terminal.screens.active.pages;
-+    
++
 +    // Get pin for this row in active area
 +    const pin = pages.pin(.{ .active = .{ .y = @intCast(y) } }) orelse return false;
 +    const rac = pin.rowAndCell();
-+    
++
 +    // wrap_continuation means this row continues from the previous row
 +    return rac.row.wrap_continuation;
 +}
@@ -1515,9 +1514,9 @@ index 000000000..73ae2e6fa
 +    const wrapper: *TerminalWrapper = @ptrCast(@alignCast(ptr orelse return -1));
 +    const len = @min(wrapper.response_buffer.items.len, buf_size);
 +    if (len == 0) return 0;
-+    
++
 +    @memcpy(out[0..len], wrapper.response_buffer.items[0..len]);
-+    
++
 +    // Remove consumed bytes from buffer
 +    if (len == wrapper.response_buffer.items.len) {
 +        wrapper.response_buffer.clearRetainingCapacity();
@@ -1530,7 +1529,7 @@ index 000000000..73ae2e6fa
 +        );
 +        wrapper.response_buffer.shrinkRetainingCapacity(wrapper.response_buffer.items.len - len);
 +    }
-+    
++
 +    return @intCast(len);
 +}
 +


### PR DESCRIPTION
## Summary

Fixes #139.

- Convert the JavaScript `scrollback` line-count budget to Ghostty's byte-based `max_scrollback` inside the WASM wrapper.
- Read viewport cells from `RenderState` cached row data instead of resolving each viewport row independently, keeping rows coherent across Ghostty page boundaries.
- Add a focused regression test using the issue's 130x39, ANSI-heavy append-only output pattern to catch scrollback drops and viewport row merging.

## Validation

- `bun run build:wasm` — passed; patch applies and rebuilt `ghostty-vt.wasm` locally for tests/build.
- `bun test lib/terminal.test.ts -t "keeps viewport coherent"` — passed.
- `bun run fmt && bun run lint && bun run typecheck && bun test && bun run build` — passed.
- `git -C ghostty apply --check ../patches/ghostty-wasm-api.patch` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Verifier findings

The issue implementation workflow converged after one verifier run with no P1-P3 findings and no non-blocking findings reported.

## Dogfooding

The workflow verifier also dogfooded the browser demo with controlled 130x39 terminal output, scrolling through ANSI-heavy `rep=` / `line=` rows. It reported coherent bottom/history/back-to-bottom views and `scrollbackLength=913`.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan — coder/ghostty-web#139

## Goal

Fix GitHub issue #139: `getViewport()` / `getLine()` can return corrupted rows when the visible viewport crosses Ghostty's internal page boundaries, and the JS `scrollback` line-count option is currently handed to Ghostty as a byte budget. Keep the change minimal, reviewable, and limited to #139.

## Verified context

- Live issue #139 is open, labeled `triage:done`, `bug`, and `accepted`. The issue describes two coupled problems:
  1. `renderStateGetViewport` in the WASM API patch resolves every viewport row independently with `pages.pin(.active)`, which can become inconsistent across internal page boundaries.
  2. JS `scrollback`/`scrollbackLimit` represents lines, but Ghostty `Terminal.init(.max_scrollback)` expects bytes.
- Related PR #133 is open and demonstrates a plausible fix: use cached `RenderState.row_data` row pins and convert scrollback lines to bytes. Its implementation direction is useful, but its two added repro test files are large/exploratory; prefer a smaller targeted regression test footprint.
- Current repo evidence:
  - `lib/terminal.ts` defaults `scrollback` to `10000` and passes it through `buildWasmConfig()` as `GhosttyTerminalConfig.scrollbackLimit`.
  - `lib/ghostty.ts` writes `config.scrollbackLimit ?? 10000` directly into the WASM config struct as `scrollback_limit`.
  - `patches/ghostty-wasm-api.patch` defines `newWithConfig()` and passes `scrollback_limit` directly to `Terminal.init(... .max_scrollback = scrollback_limit ...)`.
  - `ghostty/src/terminal/Screen.zig` documents `max_scrollback` as bytes.
  - Native `ghostty/src/terminal/render.zig` builds `RenderState.row_data.items(.pin)` using a viewport `rowIterator` and stores each row pin during `RenderState.update()`.
  - `patches/ghostty-wasm-api.patch` currently has `renderStateGetViewport()` bypassing that row-pin cache and calling `pages.pin(.{ .active = .{ .y = ... } })` per row.
- Out-of-scope follow-up discovered during planning: `lib/interfaces.ts` documents `scrollback` default as `1000` while `Terminal` uses `10000`. I searched existing issues and opened #174 with `needs-triage`. Do not fold that docs cleanup into #139 unless a maintainer explicitly asks.

## Scope boundaries

In scope:

- Correct `renderStateGetViewport()` row resolution in `patches/ghostty-wasm-api.patch`.
- Convert line-count scrollback config to the byte budget Ghostty expects before calling `Terminal.init()`.
- Rebuild and commit the generated `ghostty-vt.wasm` after patch changes.
- Add concise regression coverage for page-boundary viewport stability and scrollback retention/monotonicity.
- Validate with automated tests, build checks, and browser dogfooding evidence.

Out of scope:

- Refactoring unrelated renderer/input/selection code.
- Changing or documenting public `scrollback: 0` semantics. The current wrapper has special handling for `0`, while Ghostty's byte-level docs have their own meaning; do not characterize, test, or change that behavior in #139 unless it becomes a direct blocker, and file a separate issue if a semantic mismatch is confirmed.
- Replacing PR #133 wholesale, especially its large exploratory test files.
- Fixing unrelated docs/default mismatches such as #174.

## Recommended implementation phases

### Phase 1 — Add focused regression tests first

Add minimal regression coverage in existing test files, preferably `lib/terminal.test.ts` near the existing `Terminal Config` / render-state tests. Reuse `createIsolatedTerminal()` from `lib/test-helpers.ts`; always dispose terminals in `finally` blocks.

Target tests:

1. **Viewport page-boundary stability**
   - Create an isolated terminal with the reported dimensions: `cols: 130`, `rows: 39`, `scrollback: 10000`.
   - Write deterministic, distinct, SGR-heavy lines in repeated batches, enough to cross Ghostty page boundaries. Keep the generator small; use unique row markers like `rep=03 line=041` plus color/style escape sequences rather than copying PR #133's large repro fixture.
   - Call `term.wasmTerm!.update()` before reading viewport data.
   - Keep visible text under 130 columns; ANSI escape bytes can be long, but printable row markers must not wrap unless the assertion explicitly accounts for wrapping.
   - Avoid a trailing final `\r\n`, or explicitly account for the final blank row when computing expected viewport rows.
   - Assert:
     - Primary oracle: `getViewport()` rows decode to the expected final visible line markers, with no horizontal merging from unrelated lines.
     - `getScrollbackLength()` never decreases during append-only output before the configured scrollback limit should be reached.
     - Secondary consistency check only: `getLine(row)` and the corresponding `getViewport()` slice agree for sampled rows. Do not treat this as an independent correctness oracle because `getLine()` slices `getViewport()`.

2. **Scrollback line-count budget is not treated as raw bytes**
   - Use a small but clear configuration such as `cols: 130`, `rows: 39`, `scrollback: 10000` with repeated output, or a second faster case with a lower custom limit if it reliably fails before the fix.
   - Assert retained scrollback is consistent with a line-count budget and does not unexpectedly drop under the issue's reproduction pattern.
   - Avoid overfitting to exact Ghostty internals; prefer monotonicity and lower-bound assertions that distinguish "line count converted to bytes" from "line count passed as tiny byte budget".

Quality gate before implementation:

```bash
bun test lib/terminal.test.ts -t "viewport|scrollback"
```

Expected result before the fix: at least one new regression assertion should fail against the current `ghostty-vt.wasm`. If it does not fail, tighten only the generator/threshold within #139's described reproduction dimensions before changing production code.

Implementation workflow for the Zig patch phases:

- Prefer applying `patches/ghostty-wasm-api.patch` to the `ghostty/` submodule, editing `ghostty/src/terminal/c/terminal.zig`, then regenerating or refreshing the patch from that submodule diff. This avoids hand-editing large patch hunks incorrectly.
- Before rebuilding, verify the final patch still applies cleanly with `git -C ghostty apply --check ../patches/ghostty-wasm-api.patch` (or rely on `scripts/build-wasm.sh`, which performs this check and fails early).
- After generating the final patch, ensure the `ghostty/` submodule is returned to a clean state.

### Phase 2 — Fix scrollback unit conversion in the WASM API patch

Update `patches/ghostty-wasm-api.patch` in the generated Zig wrapper (`src/terminal/c/terminal.zig` inside the patch):

1. Add the page-layout imports needed to compute Ghostty's byte budget from rows/columns:

```zig
const pagepkg = @import("../page.zig");
const Page = pagepkg.Page;
```

2. In `newWithConfig()`, treat `cfg.scrollback_limit` as a JS line count and convert finite values to bytes before passing `.max_scrollback` to `Terminal.init()`.

Preferred shape:

```zig
const scrollback_lines: usize = if (config_) |cfg|
    if (cfg.scrollback_limit == 0) std.math.maxInt(usize) else cfg.scrollback_limit
else
    10_000;

const scrollback_limit: usize = if (scrollback_lines == std.math.maxInt(usize))
    std.math.maxInt(usize)
else blk: {
    const cap = pagepkg.std_capacity.adjust(.{ .cols = @intCast(cols) }) catch
        break :blk scrollback_lines * 1024;
    const page_size = Page.layout(cap).total_size;
    const bytes_per_line = page_size / cap.rows;
    break :blk scrollback_lines * bytes_per_line;
};
```

Implementation notes:

- Prefer Zig checked/defensive arithmetic where practical (`mul` overflow fallback to `std.math.maxInt(usize)` or a documented equivalent). The goal is fail-fast in tests without introducing user-visible crashes for valid inputs.
- Preserve the wrapper's existing `cfg.scrollback_limit == 0` branch as an implementation detail; do not add tests or documentation for `0` semantics in #139.
- Keep the TypeScript config field as a line count. At most, update the nearby comment in `lib/ghostty.ts` to say the WASM wrapper converts lines to bytes internally.
- Do not duplicate Ghostty page-size assumptions in TypeScript; the Zig wrapper has direct access to Ghostty's page layout helpers.

### Phase 3 — Fix viewport row resolution in `renderStateGetViewport()`

Update only `renderStateGetViewport()` unless tests prove another row-coordinate API must change for #139.

Minimal intended behavior:

- Stop reading rows with independent `pages.pin(.active)` calls.
- Read `const row_pins = rs.row_data.items(.pin);`, which is populated by `renderStateUpdate()` / native `RenderState.update()`.
- For each viewport row `y`, use `row_pins[y]` to obtain cells and page style/hyperlink/grapheme metadata.
- Preserve the current cell serialization fields and behavior: codepoint, fg/bg RGB, style flags, width, hyperlink ID, and grapheme length.
- Add defensive checks for impossible/stale-cache states:
  - Return `-1` if `buf_size < rows * cols` as today.
  - If `row_pins.len < rows`, fill missing rows with default cells and add a debug assertion if practical. Avoid returning `-1` here unless the TypeScript side is also changed to prevent stale cell-pool reuse, which would broaden the fix.
  - Keep default-cell fill behavior for columns beyond a row's cell span.

Important update-order assumption:

- `lib/ghostty.ts#getLine()` already calls `update()` before `getViewport()`.
- Direct tests that call `getViewport()` should call `term.wasmTerm!.update()` first.
- Do not add extra `update()` calls to `getViewport()` unless required; that would change a hot-path performance contract outside the issue's root cause.

### Phase 4 — Rebuild committed WASM artifact

Because `ghostty-vt.wasm` is committed, patch changes are not complete until the binary is rebuilt.

Commands:

```bash
bun install
bun run build:wasm
```

If Zig is unavailable, use the repo-documented/mise path used by triage:

```bash
PATH="$(mise where zig@0.15.2):$PATH" ./scripts/build-wasm.sh
```

After rebuilding:

```bash
git status --short
git -C ghostty status --short
```

Acceptance for this phase:

- Tracked changes should include the patch, generated `ghostty-vt.wasm`, and the targeted test edit(s).
- The `ghostty/` submodule worktree should be clean after `scripts/build-wasm.sh` reverts the patch.

### Phase 5 — Automated validation

Run targeted checks while iterating, then the full project gate before declaring done.

Targeted checks:

```bash
bun test lib/terminal.test.ts -t "viewport|scrollback"
bun test lib/scrolling.test.ts
```

Full validation gate:

```bash
bun run fmt && bun run lint && bun run typecheck && bun test && bun run build
```

Notes:

- `bun run build` invokes `build:wasm`, so it may rebuild the WASM artifact again; verify no unexpected binary churn afterward.
- If `bun test` hangs after reporting completion, capture the pass/fail summary and note the known hang behavior rather than claiming a clean exit that did not occur.
- If any validation failure is unrelated to #139, follow the out-of-scope issue policy instead of broadening this fix.

## Dogfooding / reviewable evidence

Because this bug affects the browser-visible terminal viewport and scrollback behavior, dogfooding should produce both automated logs and visual evidence.

Setup (follow the repo's demo/PTY instructions if they change; current repo instructions use this shape):

```bash
# Terminal 1: PTY server for the interactive demo
cd demo/server
bun install
bun run start

# Terminal 2: Vite dev server from repo root
bun run dev
```

Browser exercise:

1. Open `http://localhost:8000/demo/` using `agent-browser` or a normal browser.
2. Resize the browser/demo terminal so the terminal is near the issue reproduction shape (`cols ~= 130`, `rows ~= 39`) if feasible.
3. Paste/run an ANSI-heavy append-only output command, for example:

```bash
for rep in $(seq 1 14); do
  for i in $(seq 1 68); do
    color=$(( (rep * 17 + i) % 256 ))
    printf '\033[1;38;5;%smrep=%02d line=%02d %s\033[0m\n' "$color" "$rep" "$i" "████████████████████████████████"
  done
done
```

4. Scroll to the bottom, then into history, then back down. Look for merged rows, missing blocks, garbage characters, or scrollbar jumps.
5. Capture reviewer evidence:
   - Screenshot at the bottom after the output completes.
   - Screenshot while scrolled into history where distinct `rep=` / `line=` markers remain coherent.
   - A short video recording of scrolling through the generated output without row corruption.
6. Attach screenshots/recording artifacts to the final report or PR using `attach_file` so reviewers can inspect the exact dogfood state.

If the environment cannot provide browser screenshots/video, document the blocker explicitly and include the automated regression logs plus any terminal output snapshots that demonstrate the same invariants.

## Acceptance criteria

- The new regression test(s) fail on the current implementation or are otherwise demonstrated to reproduce #139 before the fix.
- `renderStateGetViewport()` uses cached `RenderState.row_data` row pins instead of independent `pages.pin(.active)` row resolution.
- The JS `scrollback` line count is converted to a Ghostty byte budget before being passed as `.max_scrollback`.
- `getScrollbackLength()` does not unexpectedly decrease under the issue's append-only reproduction before the configured line budget is reached.
- `getViewport()` and `getLine()` return coherent, matching visible rows across page-boundary scenarios at the reported dimensions.
- The generated `ghostty-vt.wasm` is rebuilt and included with the patch changes.
- No unrelated API/default/doc cleanup is included in the #139 diff.
- Targeted tests, full validation, and dogfooding evidence are completed or any environmental blockers are clearly reported.

## Risks and mitigations

- **Repro brittleness:** The corruption depends on page layout and column width. Start from the issue dimensions (`cols=130`, `rows=39`, `scrollback=10000`) and the triage repro pattern. Keep assertions invariant-based rather than exact-byte-layout-based.
- **RenderState cache freshness:** Cached row pins are only valid after `update()`. Tests and hot paths should maintain the current update-before-read ordering; add defensive checks in Zig for stale cache rather than silently reading undefined pins.
- **Scrollback memory increase:** Correctly converting 10,000 lines to bytes will allocate more scrollback than the buggy behavior. This is expected and required by the API contract; avoid adding new memory knobs in this issue.
- **WASM build tooling:** Rebuilding requires Zig 0.15.2+. If unavailable, this is a hard blocker for implementation completion because the committed binary must match the patch.
- **Adjacent row APIs:** `renderStateGetGrapheme()`, `isRowWrapped()`, and `getHyperlinkUri()` also resolve rows, but PR #133 and #139 specifically target `renderStateGetViewport()`. Do not expand to them unless a #139 regression test proves viewport correctness still depends on them; otherwise file/follow a separate issue.

## Advisor review status

Approved after two advisor review rounds. Round 1 requested refinements around test oracles, deterministic non-wrapping output, patch-edit workflow, `scrollback: 0` scope, stale row-pin fallback behavior, and dogfood setup wording. The plan was updated accordingly, and round 2 approved it as implementation-ready.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
