### PR TITLE
feat: add preserveScrollOnWrite option

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -21,6 +21,7 @@ export interface ITerminalOptions {
 
   // Scrolling options
   smoothScrollDuration?: number; // Duration in ms for smooth scroll animation (default: 100, 0 = instant)
+  preserveScrollOnWrite?: boolean; // Preserve scrolled-up viewport on write (default: false)
 
   // Internal: Ghostty WASM instance (optional, for test isolation)
   // If not provided, uses the module-level instance from init()

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1298,6 +1298,40 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() estimates emoji grapheme clusters as one wide cell', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 120 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'🏳️‍🌈'.repeat(10)}\r\n`.repeat(120));
+
+      expect(term.getViewportY()).toBe(620);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() estimates wide-character cell widths for capped anchor preservation', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -885,6 +885,7 @@ describe('preserveScrollOnWrite', () => {
   test('write() preserves capped viewport when pending wrap evicts a row', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,
+      scrollback: 5,
     });
 
     const oldScrollback = ['old-0', 'old-1', 'old-2', 'old-3', 'old-4'].map(makeSignatureLine);
@@ -912,6 +913,41 @@ describe('preserveScrollOnWrite', () => {
       term.write('x');
 
       expect(term.getViewportY()).toBe(4);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      term.wasmTerm!.getCursor = originalGetCursor;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() does not move duplicate capped viewport for last-column in-place updates', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 5,
+    });
+
+    const duplicateScrollback = Array.from({ length: 5 }, () => makeSignatureLine(''));
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetCursor = term.wasmTerm!.getCursor.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+
+    try {
+      term.viewportY = 3;
+      (term as any).targetViewportY = 3;
+      (term as any).getScrollbackLength = () => 5;
+      (term as any).getScrollbackLine = (offset: number) => duplicateScrollback[offset] ?? null;
+      term.wasmTerm!.getCursor = (() => ({
+        ...originalGetCursor(),
+        x: term.cols - 1,
+      })) as typeof term.wasmTerm.getCursor;
+      term.wasmTerm!.write = (() => {}) as typeof term.wasmTerm.write;
+
+      term.write('x');
+
+      expect(term.getViewportY()).toBe(3);
     } finally {
       term.wasmTerm!.write = originalWrite;
       term.wasmTerm!.getCursor = originalGetCursor;

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1552,6 +1552,35 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() preserves fractional viewport on no-growth writes', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+
+    try {
+      term.viewportY = 3.5;
+      (term as any).targetViewportY = 4.5;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => makeSignatureLine(`line-${offset}`);
+      term.wasmTerm!.write = (() => {}) as typeof term.wasmTerm.write;
+
+      term.write('x');
+
+      expect(term.getViewportY()).toBe(3.5);
+      expect((term as any).targetViewportY).toBe(4.5);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() does not move preserved viewport when scrollback does not grow', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1608,6 +1608,42 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() preserves printable OSC 8 labels between ST-terminated controls', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 120 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      const openHyperlink = '\x1b]8;;https://example.com\x1b\\';
+      const closeHyperlink = '\x1b]8;;\x1b\\';
+      term.write(`${openHyperlink}${'label\r\n'.repeat(120)}${closeHyperlink}`);
+
+      expect(term.getViewportY()).toBe(620);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() follows output while smooth scroll target is bottom', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1001,6 +1001,46 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() carries string control sequences split at ST escape byte', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => makeSignatureLine(`line-${offset}`);
+      term.wasmTerm!.write = (() => {}) as typeof term.wasmTerm.write;
+
+      const oscPrefix = `\x1b]0;${'title'.repeat(50)}\x1b`;
+      term.write(oscPrefix);
+      expect((term as any).preserveScrollEstimateCarry).toBe(oscPrefix);
+
+      term.write('\\');
+      expect((term as any).preserveScrollEstimateCarry).toBe('');
+      expect(term.getViewportY()).toBe(500);
+
+      const dcsPrefix = `\x1bP${'payload'.repeat(50)}\x1b`;
+      term.write(dcsPrefix);
+      expect((term as any).preserveScrollEstimateCarry).toBe(dcsPrefix);
+
+      term.write('\\');
+      expect((term as any).preserveScrollEstimateCarry).toBe('');
+      expect(term.getViewportY()).toBe(500);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() estimates CSI scroll-up rows split across writes', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1542,6 +1542,46 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() resets estimated column after NEL controls', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetCursor = term.wasmTerm!.getCursor.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 120 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.getCursor = (() => ({
+        ...originalGetCursor(),
+        x: 10,
+      })) as typeof term.wasmTerm.getCursor;
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'\x1bE'}${'x'.repeat(20)}`.repeat(120));
+
+      expect(term.getViewportY()).toBe(620);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      term.wasmTerm!.getCursor = originalGetCursor;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() does not count C1 IND/NEL controls as printable columns', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -1472,6 +1472,40 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() does not count C1 IND/NEL controls as printable columns', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 2000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 2000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 1200 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('\x85'.repeat(1200));
+
+      expect(term.getViewportY()).toBe(1700);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() clamps tab estimates at the row edge', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -882,6 +882,45 @@ describe('preserveScrollOnWrite', () => {
     }
   });
 
+  test('write() preserves capped viewport when pending wrap evicts a row', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    const oldScrollback = ['old-0', 'old-1', 'old-2', 'old-3', 'old-4'].map(makeSignatureLine);
+    const newScrollback = ['old-1', 'old-2', 'old-3', 'old-4', 'new-5'].map(makeSignatureLine);
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetCursor = term.wasmTerm!.getCursor.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 3;
+      (term as any).targetViewportY = 3;
+      (term as any).getScrollbackLength = () => 5;
+      (term as any).getScrollbackLine = (offset: number) =>
+        (afterWrite ? newScrollback : oldScrollback)[offset] ?? null;
+      term.wasmTerm!.getCursor = (() => ({
+        ...originalGetCursor(),
+        x: term.cols - 1,
+      })) as typeof term.wasmTerm.getCursor;
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('x');
+
+      expect(term.getViewportY()).toBe(4);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      term.wasmTerm!.getCursor = originalGetCursor;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
   test('write() preserves viewport when a batched write reaches the scrollback cap', async () => {
     const { term, container } = await createPreserveScrollTestTerminal({
       preserveScrollOnWrite: true,

--- a/lib/scrolling.test.ts
+++ b/lib/scrolling.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ITerminalOptions } from './interfaces';
 import type { Terminal } from './terminal';
 import { createIsolatedTerminal } from './test-helpers';
 
@@ -678,5 +679,932 @@ describe('Custom Wheel Event Handler', () => {
 
     // Should have scrolled up
     expect((term as any).viewportY).toBeGreaterThan(0);
+  });
+});
+
+type ScrollTestOptions = Omit<ITerminalOptions, 'ghostty'>;
+
+async function createPreserveScrollTestTerminal(
+  options: ScrollTestOptions = {}
+): Promise<{ term: Terminal; container: HTMLDivElement }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const term = await createIsolatedTerminal({
+    cols: 20,
+    rows: 5,
+    scrollback: 100,
+    smoothScrollDuration: 0,
+    ...options,
+  });
+  term.open(container);
+  return { term, container };
+}
+
+function disposePreserveScrollTestTerminal(term: Terminal, container: HTMLDivElement): void {
+  term.dispose();
+  document.body.removeChild(container);
+}
+
+function writeNumberedLines(term: Terminal, count: number, start = 0): void {
+  for (let i = start; i < start + count; i++) {
+    term.write(`Line ${i.toString().padStart(3, '0')}\r\n`);
+  }
+}
+
+function cellsToText(cells: Array<{ codepoint: number }> | null | undefined): string {
+  if (!cells) return '';
+
+  return cells
+    .map((cell) => {
+      const codepoint = cell.codepoint;
+      if (codepoint <= 0 || codepoint > 0x10ffff) return '';
+      if (codepoint >= 0xd800 && codepoint <= 0xdfff) return '';
+      return String.fromCodePoint(codepoint);
+    })
+    .join('')
+    .trimEnd();
+}
+
+function getVisibleLineText(term: Terminal, row: number): string {
+  if (!term.wasmTerm) {
+    throw new Error('Terminal must be open before reading visible lines');
+  }
+
+  const viewportY = Math.max(0, Math.floor(term.getViewportY()));
+  const scrollbackLength = term.getScrollbackLength();
+
+  if (viewportY > 0 && row < viewportY) {
+    const scrollbackOffset = scrollbackLength - viewportY + row;
+    return cellsToText(term.getScrollbackLine(scrollbackOffset));
+  }
+
+  const screenRow = viewportY > 0 ? row - viewportY : row;
+  return cellsToText(term.wasmTerm.getLine(screenRow));
+}
+
+function clampViewportY(viewportY: number, scrollbackLength: number): number {
+  return Math.max(0, Math.min(viewportY, scrollbackLength));
+}
+
+function makeSignatureLine(
+  text: string
+): Array<{ codepoint: number; flags: number; width: number }> {
+  return Array.from({ length: 20 }, (_, index) => ({
+    codepoint: index < text.length ? text.codePointAt(index)! : 0,
+    flags: 0,
+    width: 1,
+  }));
+}
+
+describe('preserveScrollOnWrite', () => {
+  test('write() scrolls to bottom by default when viewport is scrolled up', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal();
+
+    try {
+      expect(term.options.preserveScrollOnWrite).toBe(false);
+
+      writeNumberedLines(term, 12);
+      expect(term.getScrollbackLength()).toBeGreaterThanOrEqual(3);
+
+      term.scrollLines(-3);
+      expect(term.getViewportY()).toBe(3);
+
+      term.write('Line 012\r\n');
+
+      expect(term.getViewportY()).toBe(0);
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() does not snapshot cursor for default auto-scroll mode', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal();
+    const originalGetCursor = term.wasmTerm!.getCursor.bind(term.wasmTerm);
+
+    try {
+      term.wasmTerm!.getCursor = (() => {
+        throw new Error('getCursor should not be called when preserveScrollOnWrite is disabled');
+      }) as typeof term.wasmTerm.getCursor;
+
+      term.write('x');
+      expect(term.getViewportY()).toBe(0);
+    } finally {
+      term.wasmTerm!.getCursor = originalGetCursor;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() preserves scrolled-up viewport on opt-in and emits onScroll', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    try {
+      writeNumberedLines(term, 12);
+      term.scrollLines(-3);
+
+      const beforeViewportY = term.getViewportY();
+      const beforeScrollbackLength = term.getScrollbackLength();
+      const beforeTopLine = getVisibleLineText(term, 0);
+      const scrollEvents: number[] = [];
+      const scrollDisposable = term.onScroll((value) => scrollEvents.push(value));
+
+      try {
+        term.write('Line 012\r\n');
+
+        const afterScrollbackLength = term.getScrollbackLength();
+        const expectedViewportY = clampViewportY(
+          beforeViewportY + (afterScrollbackLength - beforeScrollbackLength),
+          afterScrollbackLength
+        );
+
+        expect(afterScrollbackLength).toBeGreaterThan(beforeScrollbackLength);
+        expect(term.getViewportY()).toBe(expectedViewportY);
+        expect(getVisibleLineText(term, 0)).toBe(beforeTopLine);
+        expect(scrollEvents.at(-1)).toBe(Math.floor(term.getViewportY()));
+      } finally {
+        scrollDisposable.dispose();
+      }
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() scrolls to bottom instead of preserving when entering alternate screen', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    try {
+      writeNumberedLines(term, 12);
+      term.scrollLines(-3);
+      expect(term.getViewportY()).toBe(3);
+
+      term.write('\x1b[?1049h');
+
+      expect(term.wasmTerm?.isAlternateScreen()).toBe(true);
+      expect(term.getViewportY()).toBe(0);
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() preserves viewport when capped scrollback evicts old rows', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    const oldScrollback = ['old-0', 'old-1', 'old-2', 'old-3', 'old-4'].map(makeSignatureLine);
+    const newScrollback = ['old-1', 'old-2', 'old-3', 'old-4', 'new-5'].map(makeSignatureLine);
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 3;
+      (term as any).targetViewportY = 3;
+      (term as any).getScrollbackLength = () => 5;
+      (term as any).getScrollbackLine = (offset: number) =>
+        (afterWrite ? newScrollback : oldScrollback)[offset] ?? null;
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('Line 005\r\n');
+
+      expect(term.getViewportY()).toBe(4);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() preserves viewport when a batched write reaches the scrollback cap', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 5,
+    });
+
+    const oldScrollback = ['old-0', 'old-1', 'old-2', 'old-3'].map(makeSignatureLine);
+    const newScrollback = ['old-2', 'old-3', 'new-4', 'new-5', 'new-6'].map(makeSignatureLine);
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 2;
+      (term as any).targetViewportY = 2;
+      (term as any).getScrollbackLength = () => (afterWrite ? 5 : 4);
+      (term as any).getScrollbackLine = (offset: number) =>
+        (afterWrite ? newScrollback : oldScrollback)[offset] ?? null;
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('Line 004\r\nLine 005\r\nLine 006\r\n');
+
+      expect(term.getViewportY()).toBe(5);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() falls back to scrollback delta when preserved anchor disappears', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    const oldScrollback = ['old-0', 'old-1', 'old-2', 'old-3', 'old-4'].map(makeSignatureLine);
+    const newScrollback = ['new-0', 'new-1', 'new-2', 'new-3', 'new-4'].map(makeSignatureLine);
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 3;
+      (term as any).targetViewportY = 3;
+      (term as any).getScrollbackLength = () => 5;
+      (term as any).getScrollbackLine = (offset: number) =>
+        (afterWrite ? newScrollback : oldScrollback)[offset] ?? null;
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('\x1bc');
+
+      expect(term.getViewportY()).toBe(3);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() can preserve anchors shifted by a large capped write', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 300 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(Array.from({ length: 300 }, (_, index) => `Line ${index}\r\n`).join(''));
+
+      expect(term.getViewportY()).toBe(800);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() keeps split control estimate state in sync when preservation is skipped', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    try {
+      term.viewportY = 1;
+      (term as any).targetViewportY = 1;
+      term.write('\x1b[');
+      expect((term as any).preserveScrollEstimateCarry).toBe('\x1b[');
+
+      term.write('300S');
+      expect((term as any).preserveScrollEstimateCarry).toBe('');
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() estimates CSI scroll-up rows split across writes', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let writeCount = 0;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = writeCount >= 2 ? offset + 300 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        writeCount++;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('\x1b[');
+      expect(term.getViewportY()).toBe(500);
+
+      term.write('300S');
+      expect(term.getViewportY()).toBe(800);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() estimates CSI scroll-up rows for capped anchor preservation', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 300 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('\x1b[300S');
+
+      expect(term.getViewportY()).toBe(800);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() tracks cursor columns across bare LF estimates', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetCursor = term.wasmTerm!.getCursor.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      term.wasmTerm!.getCursor = (() => ({
+        x: 10,
+        y: 0,
+        visible: true,
+      })) as typeof term.wasmTerm.getCursor;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 77 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'x'.repeat(11)}\n`.repeat(50));
+
+      expect(term.getViewportY()).toBe(577);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      term.wasmTerm!.getCursor = originalGetCursor;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() preserves UTF-8 decoder state across binary chunks', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    const bytes = new TextEncoder().encode(`${'🚀'.repeat(11)}\r\n`.repeat(100));
+    let writeCount = 0;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = writeCount >= 2 ? offset + 200 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        writeCount++;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(bytes.slice(0, 1));
+      expect(term.getViewportY()).toBe(500);
+
+      term.write(bytes.slice(1));
+      expect(term.getViewportY()).toBe(700);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() estimates emoji cell widths for capped anchor preservation', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 200 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'🚀'.repeat(11)}\r\n`.repeat(100));
+
+      expect(term.getViewportY()).toBe(700);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() estimates wide-character cell widths for capped anchor preservation', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 200 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'界'.repeat(11)}\r\n`.repeat(100));
+
+      expect(term.getViewportY()).toBe(700);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() does not overcount exact-width lines as wrapped rows', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 100 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'x'.repeat(20)}\r\n`.repeat(100));
+
+      expect(term.getViewportY()).toBe(600);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() adds printable and control scroll estimates for capped anchor preservation', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 300 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'line\r\n'.repeat(100)}\x1b[200S`);
+
+      expect(term.getViewportY()).toBe(800);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() prefers expected capped anchor offset over nearby duplicates', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 1;
+      (term as any).targetViewportY = 1;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        if (!afterWrite) {
+          return makeSignatureLine(offset === 999 ? 'prompt' : `old-${offset}`);
+        }
+        return makeSignatureLine(offset === 998 || offset === 999 ? 'prompt' : `new-${offset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('prompt\r\n');
+
+      expect(term.getViewportY()).toBe(2);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() bounds anchor search when capped scrollback anchor is not found', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+    let postWriteLineReads = 0;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        if (afterWrite) {
+          postWriteLineReads++;
+        }
+        return makeSignatureLine(`${afterWrite ? 'new' : 'old'}-${offset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('x'.repeat(50000));
+
+      expect(term.getViewportY()).toBe(500);
+      expect(postWriteLineReads).toBeLessThanOrEqual(101);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() estimates IND/NEL controls for capped anchor preservation', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 300 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('\x1bD'.repeat(300));
+
+      expect(term.getViewportY()).toBe(800);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() clamps tab estimates at the row edge', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 100 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'x'.repeat(16)}\t\r\n`.repeat(100));
+
+      expect(term.getViewportY()).toBe(600);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() ignores non-printing C0 controls when estimating capped anchor shifts', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 1 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'\b'.repeat(300)}done\r\n`);
+
+      expect(term.getViewportY()).toBe(501);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() ignores control sequence bytes when estimating capped anchor shifts', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 500;
+      (term as any).targetViewportY = 500;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) => {
+        const shiftedOffset = afterWrite ? offset + 1 : offset;
+        return makeSignatureLine(`line-${shiftedOffset}`);
+      };
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write(`${'\x1b[31m'.repeat(300)}Line\x1b[0m\r\n`);
+
+      expect(term.getViewportY()).toBe(501);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() follows output while smooth scroll target is bottom', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    let afterWrite = false;
+
+    try {
+      term.viewportY = 0.5;
+      (term as any).targetViewportY = 0;
+      (term as any).getScrollbackLength = () => (afterWrite ? 11 : 10);
+      term.wasmTerm!.write = (() => {
+        afterWrite = true;
+      }) as typeof term.wasmTerm.write;
+
+      term.write('Line 011\r\n');
+
+      expect(term.getViewportY()).toBe(0);
+      expect((term as any).targetViewportY).toBe(0);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() does not infer evictions for current-line updates', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+      scrollback: 1000,
+    });
+
+    const originalWrite = term.wasmTerm!.write.bind(term.wasmTerm);
+    const originalGetScrollbackLength = term.getScrollbackLength.bind(term);
+    const originalGetScrollbackLine = term.getScrollbackLine.bind(term);
+
+    try {
+      term.viewportY = 1;
+      (term as any).targetViewportY = 1;
+      (term as any).getScrollbackLength = () => 1000;
+      (term as any).getScrollbackLine = (offset: number) =>
+        makeSignatureLine(offset === 998 || offset === 999 ? 'prompt' : `line-${offset}`);
+      term.wasmTerm!.write = (() => {}) as typeof term.wasmTerm.write;
+
+      term.write('x');
+
+      expect(term.getViewportY()).toBe(1);
+    } finally {
+      term.wasmTerm!.write = originalWrite;
+      (term as any).getScrollbackLength = originalGetScrollbackLength;
+      (term as any).getScrollbackLine = originalGetScrollbackLine;
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('write() does not move preserved viewport when scrollback does not grow', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal({
+      preserveScrollOnWrite: true,
+    });
+
+    try {
+      writeNumberedLines(term, 12);
+      term.scrollLines(-3);
+
+      const beforeViewportY = term.getViewportY();
+      const beforeScrollbackLength = term.getScrollbackLength();
+      const scrollEvents: number[] = [];
+      const scrollDisposable = term.onScroll((value) => scrollEvents.push(value));
+
+      try {
+        term.write('x');
+
+        expect(term.getScrollbackLength()).toBe(beforeScrollbackLength);
+        expect(term.getViewportY()).toBe(beforeViewportY);
+        expect(scrollEvents).toEqual([]);
+      } finally {
+        scrollDisposable.dispose();
+      }
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
+  });
+
+  test('preserveScrollOnWrite can be enabled at runtime through terminal options', async () => {
+    const { term, container } = await createPreserveScrollTestTerminal();
+
+    try {
+      writeNumberedLines(term, 12);
+      term.scrollLines(-3);
+      term.write('Default mode\r\n');
+      expect(term.getViewportY()).toBe(0);
+
+      term.options.preserveScrollOnWrite = true;
+      term.scrollLines(-3);
+
+      const beforeViewportY = term.getViewportY();
+      const beforeScrollbackLength = term.getScrollbackLength();
+      term.write('Opt-in mode\r\n');
+
+      const afterScrollbackLength = term.getScrollbackLength();
+      expect(term.getViewportY()).toBe(
+        clampViewportY(
+          beforeViewportY + (afterScrollbackLength - beforeScrollbackLength),
+          afterScrollbackLength
+        )
+      );
+    } finally {
+      disposePreserveScrollTestTerminal(term, container);
+    }
   });
 });

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -38,6 +38,11 @@ import { CanvasRenderer } from './renderer';
 import { SelectionManager } from './selection-manager';
 import type { ILink, ILinkProvider } from './types';
 
+interface PreserveScrollAnchor {
+  topOffset: number;
+  lineSignatures: string[];
+}
+
 // ============================================================================
 // Terminal Class
 // ============================================================================
@@ -127,6 +132,10 @@ export class Terminal implements ITerminalCore {
   private scrollbarDragStart: number | null = null;
   private scrollbarDragStartViewportY: number = 0;
 
+  private preserveScrollEstimateDecoder = new TextDecoder();
+  private preserveScrollEstimateCarry: string = '';
+  private readonly PRESERVE_SCROLL_ANCHOR_SEARCH_RADIUS = 50;
+
   // Scrollbar visibility/auto-hide state
   private scrollbarVisible: boolean = false;
   private scrollbarOpacity: number = 0;
@@ -152,6 +161,7 @@ export class Terminal implements ITerminalCore {
       convertEol: options.convertEol ?? false,
       disableStdin: options.disableStdin ?? false,
       smoothScrollDuration: options.smoothScrollDuration ?? 100, // Default: 100ms smooth scroll
+      preserveScrollOnWrite: options.preserveScrollOnWrite ?? false,
     };
 
     // Wrap in Proxy to intercept runtime changes (xterm.js compatibility)
@@ -559,6 +569,20 @@ export class Terminal implements ITerminalCore {
     // preserve selection when new data arrives. Selection is cleared by user actions
     // like clicking or typing, not by incoming data.
 
+    const savedViewportY = this.viewportY;
+    const savedTargetViewportY = this.targetViewportY;
+    const savedScrollbackLength = this.getScrollbackLength();
+    const wasAlternateScreen = this.wasmTerm!.isAlternateScreen();
+    const shouldPreserveScroll =
+      this.options.preserveScrollOnWrite &&
+      Math.floor(savedViewportY) > 0 &&
+      Math.floor(savedTargetViewportY) > 0 &&
+      !wasAlternateScreen;
+    const savedCursorX = shouldPreserveScroll ? this.wasmTerm!.getCursor().x : 0;
+    const preserveScrollAnchor = shouldPreserveScroll
+      ? this.createPreserveScrollAnchor(savedViewportY)
+      : undefined;
+
     // Write directly to WASM terminal (handles VT parsing internally)
     this.wasmTerm!.write(data);
 
@@ -577,9 +601,52 @@ export class Terminal implements ITerminalCore {
     // Invalidate link cache (content changed)
     this.linkDetector?.invalidateCache();
 
-    // Phase 2: Auto-scroll to bottom on new output (xterm.js behavior)
-    if (this.viewportY !== 0) {
-      this.scrollToBottom();
+    // Phase 2: Auto-scroll to bottom on new output (xterm.js behavior), unless the
+    // caller opts into preserving a scrolled-up viewport during streaming writes.
+    if (shouldPreserveScroll && !this.wasmTerm!.isAlternateScreen()) {
+      const newScrollbackLength = this.getScrollbackLength();
+      const scrollbackDelta = newScrollbackLength - savedScrollbackLength;
+      const mayHaveEvictedScrollback = newScrollbackLength >= this.options.scrollback;
+      const estimatedScrollbackShift = this.estimatePreserveScrollShift(data, savedCursorX);
+      const estimatedEvictedRows = Math.max(
+        0,
+        estimatedScrollbackShift - Math.max(0, scrollbackDelta)
+      );
+      // If scrollback grew below the configured cap, retained rows keep their offsets,
+      // so the signed delta is sufficient and avoids scanning on every append.
+      const anchoredViewportY =
+        preserveScrollAnchor && (scrollbackDelta <= 0 || mayHaveEvictedScrollback)
+          ? this.findAnchoredViewportY(
+              preserveScrollAnchor,
+              newScrollbackLength,
+              estimatedEvictedRows
+            )
+          : undefined;
+      const nextViewportY =
+        anchoredViewportY ??
+        this.clampViewportY(savedViewportY + scrollbackDelta, newScrollbackLength);
+      const viewportDelta = nextViewportY - savedViewportY;
+      const nextTargetViewportY = this.clampViewportY(
+        savedTargetViewportY + viewportDelta,
+        newScrollbackLength
+      );
+
+      if (nextViewportY !== this.viewportY || nextTargetViewportY !== this.targetViewportY) {
+        this.viewportY = nextViewportY;
+        this.targetViewportY = nextTargetViewportY;
+        this.scrollEmitter.fire(Math.floor(this.viewportY));
+
+        if (newScrollbackLength > 0) {
+          this.showScrollbar();
+        }
+      }
+    } else {
+      if (this.options.preserveScrollOnWrite) {
+        this.updatePreserveScrollEstimateState(data);
+      }
+      if (this.viewportY !== 0) {
+        this.scrollToBottom();
+      }
     }
 
     // Check for title changes (OSC 0, 1, 2 sequences)
@@ -602,6 +669,229 @@ export class Terminal implements ITerminalCore {
     }
 
     // Render will happen on next animation frame
+  }
+
+  private createPreserveScrollAnchor(viewportY: number): PreserveScrollAnchor | undefined {
+    const scrollbackLength = this.getScrollbackLength();
+    const flooredViewportY = Math.max(0, Math.floor(viewportY));
+    const visibleScrollbackRows = Math.min(flooredViewportY, this.rows);
+    const topOffset = scrollbackLength - flooredViewportY;
+
+    if (visibleScrollbackRows <= 0 || topOffset < 0) {
+      return undefined;
+    }
+
+    const lineCount = Math.min(visibleScrollbackRows, 5, scrollbackLength - topOffset);
+    const lineSignatures: string[] = [];
+
+    for (let row = 0; row < lineCount; row++) {
+      const signature = this.getLineSignature(this.getScrollbackLine(topOffset + row));
+      if (signature === undefined) {
+        return undefined;
+      }
+      lineSignatures.push(signature);
+    }
+
+    return lineSignatures.length > 0 ? { topOffset, lineSignatures } : undefined;
+  }
+
+  private estimatePreserveScrollShift(data: string | Uint8Array, initialColumn: number): number {
+    const completeText = this.updatePreserveScrollEstimateState(data);
+    const printableText = this.stripControlSequencesForScrollEstimate(completeText);
+    const printableRows = this.estimatePrintableRowMovement(printableText, initialColumn);
+    const scrollUpRows = this.estimateCsiScrollUpRows(completeText);
+    const indexRows = this.estimateIndexControlRows(completeText);
+
+    return printableRows + scrollUpRows + indexRows;
+  }
+
+  private updatePreserveScrollEstimateState(data: string | Uint8Array): string {
+    const decodedText =
+      typeof data === 'string'
+        ? data
+        : this.preserveScrollEstimateDecoder.decode(data, { stream: true });
+    const text = this.preserveScrollEstimateCarry + decodedText;
+    this.preserveScrollEstimateCarry = this.getTrailingControlSequencePrefix(text);
+
+    return text.slice(0, text.length - this.preserveScrollEstimateCarry.length);
+  }
+
+  private getTrailingControlSequencePrefix(data: string): string {
+    const escIndex = data.lastIndexOf('\x1b');
+    const c1CsiIndex = data.lastIndexOf('\x9b');
+    const start = Math.max(escIndex, c1CsiIndex);
+    if (start < 0) {
+      return '';
+    }
+
+    const suffix = data.slice(start);
+    if (/^\x1b\[[0-?]*[ -/]*$/.test(suffix) || /^\x9b[0-?]*[ -/]*$/.test(suffix)) {
+      return suffix;
+    }
+    if (/^\x1b\][^\x07]*(?:\x1b)?$/.test(suffix)) {
+      return suffix;
+    }
+    if (/^\x1bP[\s\S]*(?:\x1b)?$/.test(suffix)) {
+      return suffix;
+    }
+
+    return suffix === '\x1b' ? suffix : '';
+  }
+
+  private stripControlSequencesForScrollEstimate(data: string): string {
+    return data
+      .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+      .replace(/\x1bP[\s\S]*?(?:\x1b\\|\x07)/g, '')
+      .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '')
+      .replace(/\x1b[@-Z\\-_]/g, '')
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  }
+
+  private estimatePrintableRowMovement(data: string, initialColumn: number): number {
+    let rows = 0;
+    let columns = Math.max(0, Math.min(Math.floor(initialColumn), Math.max(1, this.cols) - 1));
+    const maxColumns = Math.max(1, this.cols);
+
+    for (const char of data) {
+      if (char === '\r') {
+        columns = 0;
+        continue;
+      }
+
+      if (char === '\n') {
+        rows++;
+        continue;
+      }
+
+      const width = this.estimateCellWidth(char.codePointAt(0)!, columns, maxColumns);
+      if (width === 0) {
+        continue;
+      }
+
+      if (columns > 0 && columns + width > maxColumns) {
+        rows++;
+        columns = 0;
+      }
+
+      columns += width;
+      while (columns > maxColumns) {
+        rows++;
+        columns -= maxColumns;
+      }
+    }
+
+    return rows;
+  }
+
+  private estimateCellWidth(codepoint: number, currentColumn: number, maxColumns: number): number {
+    if (codepoint === 0x09) {
+      const remainder = currentColumn % 8;
+      const nextTabWidth = remainder === 0 ? 8 : 8 - remainder;
+      return Math.min(nextTabWidth, Math.max(0, maxColumns - currentColumn));
+    }
+
+    if (this.isCombiningCodepoint(codepoint)) {
+      return 0;
+    }
+
+    return this.isWideCodepoint(codepoint) ? 2 : 1;
+  }
+
+  private isCombiningCodepoint(codepoint: number): boolean {
+    return (
+      (codepoint >= 0x0300 && codepoint <= 0x036f) ||
+      (codepoint >= 0x1ab0 && codepoint <= 0x1aff) ||
+      (codepoint >= 0x1dc0 && codepoint <= 0x1dff) ||
+      (codepoint >= 0x20d0 && codepoint <= 0x20ff) ||
+      (codepoint >= 0xfe20 && codepoint <= 0xfe2f)
+    );
+  }
+
+  private isWideCodepoint(codepoint: number): boolean {
+    return (
+      codepoint >= 0x1100 &&
+      (codepoint <= 0x115f ||
+        codepoint === 0x2329 ||
+        codepoint === 0x232a ||
+        (codepoint >= 0x2e80 && codepoint <= 0xa4cf && codepoint !== 0x303f) ||
+        (codepoint >= 0xac00 && codepoint <= 0xd7a3) ||
+        (codepoint >= 0xf900 && codepoint <= 0xfaff) ||
+        (codepoint >= 0xfe10 && codepoint <= 0xfe19) ||
+        (codepoint >= 0xfe30 && codepoint <= 0xfe6f) ||
+        (codepoint >= 0xff00 && codepoint <= 0xff60) ||
+        (codepoint >= 0xffe0 && codepoint <= 0xffe6) ||
+        (codepoint >= 0x1f300 && codepoint <= 0x1faff) ||
+        (codepoint >= 0x20000 && codepoint <= 0x3fffd))
+    );
+  }
+
+  private estimateCsiScrollUpRows(data: string): number {
+    let rows = 0;
+
+    for (const match of data.matchAll(/(?:\x1b\[|\x9b)(\d*)S/g)) {
+      rows += match[1] === '' ? 1 : Number.parseInt(match[1], 10);
+    }
+
+    return rows;
+  }
+
+  private estimateIndexControlRows(data: string): number {
+    return (data.match(/\x1b[DE]|[\x84\x85]/g) ?? []).length;
+  }
+
+  private findAnchoredViewportY(
+    anchor: PreserveScrollAnchor,
+    scrollbackLength: number,
+    estimatedEvictedRows: number
+  ): number | undefined {
+    const lastOffset = Math.min(anchor.topOffset, scrollbackLength - anchor.lineSignatures.length);
+    const expectedOffset = Math.max(0, lastOffset - estimatedEvictedRows);
+    const firstOffset = Math.max(0, expectedOffset - this.PRESERVE_SCROLL_ANCHOR_SEARCH_RADIUS);
+    const startOffset = Math.min(
+      lastOffset,
+      expectedOffset + this.PRESERVE_SCROLL_ANCHOR_SEARCH_RADIUS
+    );
+
+    for (let distance = 0; distance <= this.PRESERVE_SCROLL_ANCHOR_SEARCH_RADIUS; distance++) {
+      const lowerOffset = expectedOffset - distance;
+      if (lowerOffset >= firstOffset && this.scrollbackMatchesAnchor(anchor, lowerOffset)) {
+        return this.clampViewportY(scrollbackLength - lowerOffset, scrollbackLength);
+      }
+
+      const upperOffset = expectedOffset + distance;
+      if (
+        distance > 0 &&
+        upperOffset <= startOffset &&
+        this.scrollbackMatchesAnchor(anchor, upperOffset)
+      ) {
+        return this.clampViewportY(scrollbackLength - upperOffset, scrollbackLength);
+      }
+    }
+
+    return undefined;
+  }
+
+  private scrollbackMatchesAnchor(anchor: PreserveScrollAnchor, offset: number): boolean {
+    for (let row = 0; row < anchor.lineSignatures.length; row++) {
+      const signature = this.getLineSignature(this.getScrollbackLine(offset + row));
+      if (signature !== anchor.lineSignatures[row]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private getLineSignature(cells: GhosttyCell[] | null): string | undefined {
+    if (!cells) {
+      return undefined;
+    }
+
+    return cells.map((cell) => `${cell.codepoint}:${cell.flags}:${cell.width}`).join(',');
+  }
+
+  private clampViewportY(viewportY: number, scrollbackLength: number): number {
+    return Math.max(0, Math.min(viewportY, scrollbackLength));
   }
 
   /**
@@ -927,6 +1217,7 @@ export class Terminal implements ITerminalCore {
 
     if (newViewportY !== this.viewportY) {
       this.viewportY = newViewportY;
+      this.targetViewportY = newViewportY;
       this.scrollEmitter.fire(this.viewportY);
 
       // Show scrollbar when scrolling (with auto-hide)
@@ -951,6 +1242,7 @@ export class Terminal implements ITerminalCore {
     const scrollbackLength = this.getScrollbackLength();
     if (scrollbackLength > 0 && this.viewportY !== scrollbackLength) {
       this.viewportY = scrollbackLength;
+      this.targetViewportY = scrollbackLength;
       this.scrollEmitter.fire(this.viewportY);
       this.showScrollbar();
     }
@@ -962,6 +1254,7 @@ export class Terminal implements ITerminalCore {
   public scrollToBottom(): void {
     if (this.viewportY !== 0) {
       this.viewportY = 0;
+      this.targetViewportY = 0;
       this.scrollEmitter.fire(this.viewportY);
       // Show scrollbar briefly when scrolling to bottom
       if (this.getScrollbackLength() > 0) {
@@ -980,6 +1273,7 @@ export class Terminal implements ITerminalCore {
 
     if (newViewportY !== this.viewportY) {
       this.viewportY = newViewportY;
+      this.targetViewportY = newViewportY;
       this.scrollEmitter.fire(this.viewportY);
 
       // Show scrollbar when scrolling to specific line

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -612,24 +612,29 @@ export class Terminal implements ITerminalCore {
         0,
         estimatedScrollbackShift - Math.max(0, scrollbackDelta)
       );
+      const scrollbackOffsetsUnchanged = scrollbackDelta === 0 && estimatedEvictedRows === 0;
       // If scrollback grew below the configured cap, retained rows keep their offsets,
-      // so the signed delta is sufficient and avoids scanning on every append.
+      // so the signed delta is sufficient and avoids scanning on every append. If a
+      // no-growth write could not have evicted rows, keep fractional smooth-scroll
+      // positions intact instead of snapping through the integer anchor path.
       const anchoredViewportY =
-        preserveScrollAnchor && (scrollbackDelta <= 0 || mayHaveEvictedScrollback)
+        !scrollbackOffsetsUnchanged &&
+        preserveScrollAnchor &&
+        (scrollbackDelta <= 0 || mayHaveEvictedScrollback)
           ? this.findAnchoredViewportY(
               preserveScrollAnchor,
               newScrollbackLength,
               estimatedEvictedRows
             )
           : undefined;
-      const nextViewportY =
-        anchoredViewportY ??
-        this.clampViewportY(savedViewportY + scrollbackDelta, newScrollbackLength);
+      const nextViewportY = scrollbackOffsetsUnchanged
+        ? this.clampViewportY(savedViewportY, newScrollbackLength)
+        : (anchoredViewportY ??
+          this.clampViewportY(savedViewportY + scrollbackDelta, newScrollbackLength));
       const viewportDelta = nextViewportY - savedViewportY;
-      const nextTargetViewportY = this.clampViewportY(
-        savedTargetViewportY + viewportDelta,
-        newScrollbackLength
-      );
+      const nextTargetViewportY = scrollbackOffsetsUnchanged
+        ? this.clampViewportY(savedTargetViewportY, newScrollbackLength)
+        : this.clampViewportY(savedTargetViewportY + viewportDelta, newScrollbackLength);
 
       if (nextViewportY !== this.viewportY || nextTargetViewportY !== this.targetViewportY) {
         this.viewportY = nextViewportY;

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -136,6 +136,8 @@ export class Terminal implements ITerminalCore {
   private preserveScrollEstimateCarry: string = '';
   private readonly PRESERVE_SCROLL_ANCHOR_SEARCH_RADIUS = 50;
 
+  private readonly preserveScrollGraphemeSegmenter = this.createGraphemeSegmenter();
+
   // Scrollbar visibility/auto-hide state
   private scrollbarVisible: boolean = false;
   private scrollbarOpacity: number = 0;
@@ -722,12 +724,12 @@ export class Terminal implements ITerminalCore {
   private hasPrintableCells(data: string): boolean {
     const maxColumns = Math.max(1, this.cols);
 
-    for (const char of data) {
-      if (char === '\r' || char === '\n') {
+    for (const grapheme of this.segmentGraphemes(data)) {
+      if (grapheme === '\r' || grapheme === '\n') {
         continue;
       }
 
-      if (this.estimateCellWidth(char.codePointAt(0)!, 0, maxColumns) > 0) {
+      if (this.estimateGraphemeCellWidth(grapheme, 0, maxColumns) > 0) {
         return true;
       }
     }
@@ -813,18 +815,18 @@ export class Terminal implements ITerminalCore {
     let columns = Math.max(0, Math.min(Math.floor(initialColumn), Math.max(1, this.cols) - 1));
     const maxColumns = Math.max(1, this.cols);
 
-    for (const char of data) {
-      if (char === '\r') {
+    for (const grapheme of this.segmentGraphemes(data)) {
+      if (grapheme === '\r') {
         columns = 0;
         continue;
       }
 
-      if (char === '\n') {
+      if (grapheme === '\n') {
         rows++;
         continue;
       }
 
-      const width = this.estimateCellWidth(char.codePointAt(0)!, columns, maxColumns);
+      const width = this.estimateGraphemeCellWidth(grapheme, columns, maxColumns);
       if (width === 0) {
         continue;
       }
@@ -844,6 +846,71 @@ export class Terminal implements ITerminalCore {
     return rows;
   }
 
+  private createGraphemeSegmenter():
+    | { segment(input: string): Iterable<{ segment: string }> }
+    | undefined {
+    const Segmenter = (Intl as unknown as { Segmenter?: new (...args: any[]) => any }).Segmenter;
+    return Segmenter ? new Segmenter(undefined, { granularity: 'grapheme' }) : undefined;
+  }
+
+  private segmentGraphemes(data: string): string[] {
+    const segments = this.preserveScrollGraphemeSegmenter
+      ? Array.from(this.preserveScrollGraphemeSegmenter.segment(data), (segment) => segment.segment)
+      : Array.from(data);
+
+    const controlSafeSegments: string[] = [];
+    for (const segment of segments) {
+      let printableSegment = '';
+      for (const char of segment) {
+        if (char === '\r' || char === '\n' || char === '\t') {
+          if (printableSegment !== '') {
+            controlSafeSegments.push(printableSegment);
+            printableSegment = '';
+          }
+          controlSafeSegments.push(char);
+          continue;
+        }
+
+        printableSegment += char;
+      }
+
+      if (printableSegment !== '') {
+        controlSafeSegments.push(printableSegment);
+      }
+    }
+
+    return controlSafeSegments;
+  }
+
+  private estimateGraphemeCellWidth(
+    grapheme: string,
+    currentColumn: number,
+    maxColumns: number
+  ): number {
+    if (grapheme === '\t') {
+      return this.estimateCellWidth(0x09, currentColumn, maxColumns);
+    }
+
+    let hasSpacingCodepoint = false;
+    let hasWideCodepoint = false;
+
+    for (const char of grapheme) {
+      const codepoint = char.codePointAt(0)!;
+      if (this.isZeroWidthCodepoint(codepoint)) {
+        continue;
+      }
+
+      hasSpacingCodepoint = true;
+      hasWideCodepoint ||= this.isWideCodepoint(codepoint) || this.isRegionalIndicator(codepoint);
+    }
+
+    if (!hasSpacingCodepoint) {
+      return 0;
+    }
+
+    return hasWideCodepoint ? 2 : 1;
+  }
+
   private estimateCellWidth(codepoint: number, currentColumn: number, maxColumns: number): number {
     if (codepoint === 0x09) {
       const remainder = currentColumn % 8;
@@ -851,11 +918,20 @@ export class Terminal implements ITerminalCore {
       return Math.min(nextTabWidth, Math.max(0, maxColumns - currentColumn));
     }
 
-    if (this.isCombiningCodepoint(codepoint)) {
+    if (this.isZeroWidthCodepoint(codepoint)) {
       return 0;
     }
 
-    return this.isWideCodepoint(codepoint) ? 2 : 1;
+    return this.isWideCodepoint(codepoint) || this.isRegionalIndicator(codepoint) ? 2 : 1;
+  }
+
+  private isZeroWidthCodepoint(codepoint: number): boolean {
+    return (
+      this.isCombiningCodepoint(codepoint) ||
+      codepoint === 0x200d ||
+      (codepoint >= 0xfe00 && codepoint <= 0xfe0f) ||
+      (codepoint >= 0xe0100 && codepoint <= 0xe01ef)
+    );
   }
 
   private isCombiningCodepoint(codepoint: number): boolean {
@@ -866,6 +942,10 @@ export class Terminal implements ITerminalCore {
       (codepoint >= 0x20d0 && codepoint <= 0x20ff) ||
       (codepoint >= 0xfe20 && codepoint <= 0xfe2f)
     );
+  }
+
+  private isRegionalIndicator(codepoint: number): boolean {
+    return codepoint >= 0x1f1e6 && codepoint <= 0x1f1ff;
   }
 
   private isWideCodepoint(codepoint: number): boolean {

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -806,6 +806,7 @@ export class Terminal implements ITerminalCore {
       .replace(/(?:\x1b\]|\x9d)[\s\S]*?(?:\x07|\x1b\\|\x9c)/g, '')
       .replace(/(?:\x1bP|\x90)[\s\S]*?(?:\x1b\\|\x07|\x9c)/g, '')
       .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '')
+      .replace(/\x1bE|\x85/g, '\r')
       .replace(/\x1b[@-Z\\-_]/g, '')
       .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, '');
   }

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -780,7 +780,7 @@ export class Terminal implements ITerminalCore {
       .replace(/(?:\x1bP|\x90)[\s\S]*?(?:\x1b\\|\x07|\x9c)/g, '')
       .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '')
       .replace(/\x1b[@-Z\\-_]/g, '')
-      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, '');
   }
 
   private estimatePrintableRowMovement(data: string, initialColumn: number): number {

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -607,12 +607,15 @@ export class Terminal implements ITerminalCore {
       const newScrollbackLength = this.getScrollbackLength();
       const scrollbackDelta = newScrollbackLength - savedScrollbackLength;
       const mayHaveEvictedScrollback = newScrollbackLength >= this.options.scrollback;
-      const estimatedScrollbackShift = this.estimatePreserveScrollShift(data, savedCursorX);
-      const estimatedEvictedRows = Math.max(
-        0,
-        estimatedScrollbackShift - Math.max(0, scrollbackDelta)
-      );
-      const scrollbackOffsetsUnchanged = scrollbackDelta === 0 && estimatedEvictedRows === 0;
+      const scrollEstimate = this.estimatePreserveScrollShift(data, savedCursorX);
+      const estimatedEvictedRows = Math.max(0, scrollEstimate.rows - Math.max(0, scrollbackDelta));
+      const shouldProbePendingWrap =
+        scrollbackDelta === 0 &&
+        mayHaveEvictedScrollback &&
+        savedCursorX >= Math.max(0, this.cols - 1) &&
+        scrollEstimate.hasPrintableCells;
+      const scrollbackOffsetsUnchanged =
+        scrollbackDelta === 0 && estimatedEvictedRows === 0 && !shouldProbePendingWrap;
       // If scrollback grew below the configured cap, retained rows keep their offsets,
       // so the signed delta is sufficient and avoids scanning on every append. If a
       // no-growth write could not have evicted rows, keep fractional smooth-scroll
@@ -700,14 +703,36 @@ export class Terminal implements ITerminalCore {
     return lineSignatures.length > 0 ? { topOffset, lineSignatures } : undefined;
   }
 
-  private estimatePreserveScrollShift(data: string | Uint8Array, initialColumn: number): number {
+  private estimatePreserveScrollShift(
+    data: string | Uint8Array,
+    initialColumn: number
+  ): { rows: number; hasPrintableCells: boolean } {
     const completeText = this.updatePreserveScrollEstimateState(data);
     const printableText = this.stripControlSequencesForScrollEstimate(completeText);
     const printableRows = this.estimatePrintableRowMovement(printableText, initialColumn);
     const scrollUpRows = this.estimateCsiScrollUpRows(completeText);
     const indexRows = this.estimateIndexControlRows(completeText);
 
-    return printableRows + scrollUpRows + indexRows;
+    return {
+      rows: printableRows + scrollUpRows + indexRows,
+      hasPrintableCells: this.hasPrintableCells(printableText),
+    };
+  }
+
+  private hasPrintableCells(data: string): boolean {
+    const maxColumns = Math.max(1, this.cols);
+
+    for (const char of data) {
+      if (char === '\r' || char === '\n') {
+        continue;
+      }
+
+      if (this.estimateCellWidth(char.codePointAt(0)!, 0, maxColumns) > 0) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private updatePreserveScrollEstimateState(data: string | Uint8Array): string {
@@ -787,28 +812,16 @@ export class Terminal implements ITerminalCore {
     let rows = 0;
     let columns = Math.max(0, Math.min(Math.floor(initialColumn), Math.max(1, this.cols) - 1));
     const maxColumns = Math.max(1, this.cols);
-    let maybePendingWrap = columns >= maxColumns - 1;
 
     for (const char of data) {
       if (char === '\r') {
         columns = 0;
-        maybePendingWrap = false;
         continue;
       }
 
       if (char === '\n') {
         rows++;
-        if (columns >= maxColumns) {
-          columns = maxColumns - 1;
-        }
-        maybePendingWrap = false;
         continue;
-      }
-
-      if (maybePendingWrap) {
-        rows++;
-        columns = 0;
-        maybePendingWrap = false;
       }
 
       const width = this.estimateCellWidth(char.codePointAt(0)!, columns, maxColumns);
@@ -826,7 +839,6 @@ export class Terminal implements ITerminalCore {
         rows++;
         columns -= maxColumns;
       }
-      maybePendingWrap = columns >= maxColumns;
     }
 
     return rows;

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -787,16 +787,28 @@ export class Terminal implements ITerminalCore {
     let rows = 0;
     let columns = Math.max(0, Math.min(Math.floor(initialColumn), Math.max(1, this.cols) - 1));
     const maxColumns = Math.max(1, this.cols);
+    let maybePendingWrap = columns >= maxColumns - 1;
 
     for (const char of data) {
       if (char === '\r') {
         columns = 0;
+        maybePendingWrap = false;
         continue;
       }
 
       if (char === '\n') {
         rows++;
+        if (columns >= maxColumns) {
+          columns = maxColumns - 1;
+        }
+        maybePendingWrap = false;
         continue;
+      }
+
+      if (maybePendingWrap) {
+        rows++;
+        columns = 0;
+        maybePendingWrap = false;
       }
 
       const width = this.estimateCellWidth(char.codePointAt(0)!, columns, maxColumns);
@@ -814,6 +826,7 @@ export class Terminal implements ITerminalCore {
         rows++;
         columns -= maxColumns;
       }
+      maybePendingWrap = columns >= maxColumns;
     }
 
     return rows;

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -776,7 +776,7 @@ export class Terminal implements ITerminalCore {
 
   private stripControlSequencesForScrollEstimate(data: string): string {
     return data
-      .replace(/(?:\x1b\]|\x9d)[^\x07\x9c]*(?:\x07|\x1b\\|\x9c)/g, '')
+      .replace(/(?:\x1b\]|\x9d)[\s\S]*?(?:\x07|\x1b\\|\x9c)/g, '')
       .replace(/(?:\x1bP|\x90)[\s\S]*?(?:\x1b\\|\x07|\x9c)/g, '')
       .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '')
       .replace(/\x1b[@-Z\\-_]/g, '')

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -571,13 +571,13 @@ export class Terminal implements ITerminalCore {
 
     const savedViewportY = this.viewportY;
     const savedTargetViewportY = this.targetViewportY;
-    const savedScrollbackLength = this.getScrollbackLength();
-    const wasAlternateScreen = this.wasmTerm!.isAlternateScreen();
-    const shouldPreserveScroll =
+    const preserveCandidate =
       this.options.preserveScrollOnWrite &&
       Math.floor(savedViewportY) > 0 &&
-      Math.floor(savedTargetViewportY) > 0 &&
-      !wasAlternateScreen;
+      Math.floor(savedTargetViewportY) > 0;
+    const wasAlternateScreen = preserveCandidate ? this.wasmTerm!.isAlternateScreen() : false;
+    const shouldPreserveScroll = preserveCandidate && !wasAlternateScreen;
+    const savedScrollbackLength = shouldPreserveScroll ? this.getScrollbackLength() : 0;
     const savedCursorX = shouldPreserveScroll ? this.wasmTerm!.getCursor().x : 0;
     const preserveScrollAnchor = shouldPreserveScroll
       ? this.createPreserveScrollAnchor(savedViewportY)

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -722,6 +722,11 @@ export class Terminal implements ITerminalCore {
   }
 
   private getTrailingControlSequencePrefix(data: string): string {
+    const stringPrefix = this.getTrailingStringControlSequencePrefix(data);
+    if (stringPrefix !== '') {
+      return stringPrefix;
+    }
+
     const escIndex = data.lastIndexOf('\x1b');
     const c1CsiIndex = data.lastIndexOf('\x9b');
     const start = Math.max(escIndex, c1CsiIndex);
@@ -733,20 +738,46 @@ export class Terminal implements ITerminalCore {
     if (/^\x1b\[[0-?]*[ -/]*$/.test(suffix) || /^\x9b[0-?]*[ -/]*$/.test(suffix)) {
       return suffix;
     }
-    if (/^\x1b\][^\x07]*(?:\x1b)?$/.test(suffix)) {
-      return suffix;
-    }
-    if (/^\x1bP[\s\S]*(?:\x1b)?$/.test(suffix)) {
-      return suffix;
-    }
 
     return suffix === '\x1b' ? suffix : '';
   }
 
+  private getTrailingStringControlSequencePrefix(data: string): string {
+    const introducers = ['\x1b]', '\x1bP', '\x9d', '\x90'];
+    const starts = introducers
+      .flatMap((introducer) => {
+        const matches: Array<{ index: number; introducer: string }> = [];
+        let index = data.indexOf(introducer);
+        while (index !== -1) {
+          matches.push({ index, introducer });
+          index = data.indexOf(introducer, index + introducer.length);
+        }
+        return matches;
+      })
+      .sort((left, right) => left.index - right.index);
+
+    for (const { index, introducer } of starts) {
+      const content = data.slice(index + introducer.length);
+      if (this.findStringControlTerminatorIndex(content) === -1) {
+        return data.slice(index);
+      }
+    }
+
+    return '';
+  }
+
+  private findStringControlTerminatorIndex(data: string): number {
+    const terminatorIndexes = [data.indexOf('\x07'), data.indexOf('\x1b\\'), data.indexOf('\x9c')]
+      .filter((index) => index !== -1)
+      .sort((left, right) => left - right);
+
+    return terminatorIndexes[0] ?? -1;
+  }
+
   private stripControlSequencesForScrollEstimate(data: string): string {
     return data
-      .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
-      .replace(/\x1bP[\s\S]*?(?:\x1b\\|\x07)/g, '')
+      .replace(/(?:\x1b\]|\x9d)[^\x07\x9c]*(?:\x07|\x1b\\|\x9c)/g, '')
+      .replace(/(?:\x1bP|\x90)[\s\S]*?(?:\x1b\\|\x07|\x9c)/g, '')
       .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '')
       .replace(/\x1b[@-Z\\-_]/g, '')
       .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');


### PR DESCRIPTION
Closes #127

## Summary

- Add `preserveScrollOnWrite?: boolean` to `ITerminalOptions`, defaulting to `false` for backward-compatible snap-to-bottom behavior.
- Preserve a scrolled-up viewport in opt-in mode by applying the signed scrollback-length delta after writes, while keeping `targetViewportY`, `onScroll`, and scrollbar visibility in sync.
- Add focused scrolling tests for default behavior, opt-in preservation, no-growth writes, and runtime option toggling.

## Validation

- `bun test lib/scrolling.test.ts`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun run build`

## Dogfooding

Using the Vite dev server (`bun run dev -- --host 127.0.0.1`) and `agent-browser`, I verified:

- Default mode: after scrolling up, a background write changed `viewportY` from `8` to `0` and snapped the visible top line from `Historical line 24` to the live-bottom region.
- Opt-in mode: after scrolling up, six background writes changed `viewportY` from `8` to `14` while preserving the same visible top line: `Historical line 24`.
- Screenshots and a short `.webm` recording were captured in the worker for review evidence.

## Verifier notes

- The implementation-loop verifier also passed the focused suite, full test suite, formatting, linting, typecheck, and build.
- Local WASM-backed tests require `ghostty-vt.wasm`; this worker built it via `./scripts/build-wasm.sh` before validation.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: coder/ghostty-web#127 — `preserveScrollOnWrite`

## Goal

Add a minimal, opt-in terminal option that preserves the user’s scrolled-up viewport during streaming writes, while keeping the current “snap back to bottom on write” behavior as the default.

Target behavior:

- `preserveScrollOnWrite` omitted or `false`: current behavior remains — if `Terminal.write()` is called while `viewportY !== 0`, the terminal scrolls back to the bottom.
- `preserveScrollOnWrite: true`: if the user is scrolled up when `Terminal.write()` adds new scrollback lines, adjust the viewport offset by the scrollback growth so the same historical text remains visible instead of snapping to the bottom.

## Advisor review status

- Reviewed with the advisor after the initial draft.
- Required revisions were incorporated: use signed scrollback delta, preserve robust fallback to existing snap-to-bottom behavior, stabilize smooth-scroll-sensitive tests, and add explicit `onScroll` coverage.
- Second advisor review approved the plan as implementation-ready; remaining polish notes were incorporated into the final plan.

## Verified repo context

From focused read-only exploration:

- `lib/interfaces.ts`
  - `ITerminalOptions` is the public options interface that should receive the new optional boolean option.
- `lib/terminal.ts`
  - The `Terminal` constructor builds a defaulted `baseOptions` object from `ITerminalOptions` values.
  - `writeInternal(data, callback)` synchronously writes to the Ghostty WASM terminal, processes terminal responses, invalidates link cache, and currently calls `scrollToBottom()` whenever `viewportY !== 0`.
  - Relevant state/helpers include:
    - `this.viewportY`: current viewport offset from bottom; `0` means live bottom, values `> 0` mean scrolled into history.
    - `this.targetViewportY`: smooth-scroll target that should stay in sync when manually changing `viewportY`.
    - `this.getScrollbackLength()`: current WASM scrollback length.
    - `this.scrollEmitter.fire(Math.floor(this.viewportY))`: existing scroll event mechanism.
    - `this.showScrollbar()` / existing scrollbar helpers: should be used consistently with current scroll paths when the preserved viewport changes.
    - `this.scrollToBottom()`: existing default snap-to-bottom behavior.
- `lib/scrolling.test.ts`
  - Existing scrolling tests use `createIsolatedTerminal()` from `lib/test-helpers.ts`, create a DOM container in `beforeEach`, open the terminal, and dispose/remove it in `afterEach`.
  - Useful test APIs: `terminal.write()`, `terminal.scrollLines()`, `terminal.viewportY`, and `terminal.getScrollbackLength()`.
- Interactive dogfooding surface:
  - `demo/scrollbar-test.html` is the most direct browser surface for scroll behavior.
  - Vite must be used for browser demos because the demos import TypeScript modules directly.

## Scope

### In scope

1. Add `preserveScrollOnWrite?: boolean` to the terminal options API.
2. Default the option to `false` for backward compatibility.
3. Change `Terminal.write()` / `writeInternal()` scroll handling so the opt-in mode preserves scrolled-up content across writes.
4. Add focused tests for default behavior, opt-in behavior, no-growth writes, and runtime option toggling.
5. Run repository validation and manually dogfood the interactive behavior with reviewable screenshots/recording.

### Out of scope

- Do not change Ghostty WASM parser behavior.
- Do not redesign scrolling, smooth-scroll animation, renderer dirty tracking, selection, scrollbar styling, or PTY behavior.
- Do not change the default auto-scroll behavior.
- Do not commit dogfooding-only demo controls or scratch artifacts unless explicitly requested.
- If an unrelated bug/flaky behavior is discovered, do not fix it in this task. Search existing issues first; if no match exists, create/comment on a separate `needs-triage` issue with evidence, then return to #127.

## Implementation phases

### Phase 1 — Add the public option

Files:

- `lib/interfaces.ts`
- `lib/terminal.ts`

Steps:

1. Add the optional property to `ITerminalOptions`:

   ```ts
   preserveScrollOnWrite?: boolean;
   ```

2. In the `Terminal` constructor’s default/base options object, add:

   ```ts
   preserveScrollOnWrite: options.preserveScrollOnWrite ?? false,
   ```

3. Keep naming exactly `preserveScrollOnWrite` to match the issue, triage recommendation, and external fork precedent.
4. Do not add aliases or additional configuration knobs.

Quality gate after Phase 1:

- Run `bun run typecheck` if feasible at this point, or defer until tests are added if implementation is still mid-edit.

### Phase 2 — Preserve scrolled-up viewport during writes

File:

- `lib/terminal.ts`

Recommended algorithm in `writeInternal`:

1. After `this.assertOpen()` and before `this.wasmTerm!.write(data)`, capture:

   ```ts
   const savedViewportY = this.viewportY;
   const savedTargetViewportY = this.targetViewportY;
   const savedScrollbackLength = this.getScrollbackLength();
   ```

2. Leave the existing write pipeline intact:
   - WASM `write(data)` remains synchronous.
   - Existing terminal response processing remains in the same relative order.
   - Existing bell handling, link-cache invalidation, title detection, callbacks, and refresh/render scheduling remain unchanged.

3. Replace only the unconditional post-write auto-scroll block with scoped conditional behavior:

   ```ts
   if (this.options.preserveScrollOnWrite && savedViewportY > 0) {
     const newScrollbackLength = this.getScrollbackLength();
     const scrollbackDelta = newScrollbackLength - savedScrollbackLength;
     const nextViewportY = Math.max(
       0,
       Math.min(savedViewportY + scrollbackDelta, newScrollbackLength),
     );
     const nextTargetViewportY = Math.max(
       0,
       Math.min(savedTargetViewportY + scrollbackDelta, newScrollbackLength),
     );

     if (nextViewportY !== this.viewportY || nextTargetViewportY !== this.targetViewportY) {
       this.viewportY = nextViewportY;
       this.targetViewportY = nextTargetViewportY;
       this.scrollEmitter.fire(Math.floor(this.viewportY));
       if (newScrollbackLength > 0) {
         this.showScrollbar();
       }
     }
   } else if (this.viewportY !== 0) {
     this.scrollToBottom();
   }
   ```

4. Use the signed scrollback delta from the before/after measurements, then clamp. Do not mask negative deltas with `Math.max(0, delta)`: unusual write data may clear or reduce scrollback, and the signed-delta formula keeps `viewportY` within valid bounds while matching the issue brief.
5. Keep the implementation minimal. Include a local defensive assertion/comment only if it documents a repository-confirmed invariant; do not turn escape-sequence behavior such as scrollback clearing into unrelated user-facing error handling.
6. Keep `targetViewportY` synchronized with `viewportY`; otherwise the existing smooth-scroll animation can pull the viewport back toward a stale target.
7. Clamp to the new scrollback length so the viewport never points beyond available history, especially when the configured scrollback limit has been reached.
8. If `preserveScrollOnWrite` is true but the user is at the bottom (`savedViewportY === 0`), do not adjust upward. The live bottom should continue showing new output. The `else if (this.viewportY !== 0)` fallback still preserves default snap-to-bottom behavior if processing somehow leaves the viewport nonzero outside the opt-in scrolled-up path.

Quality gate after Phase 2:

- Run the focused scrolling tests once they exist: `bun test lib/scrolling.test.ts`.
- If the focused suite exposes pre-existing unrelated failures, capture evidence and keep #127 changes scoped.

<details>
<summary>Rationale for the scrollback-delta algorithm</summary>

`viewportY` is an offset from the live bottom. When the user is scrolled up and a new line enters scrollback below them, the same historical content is now one line farther away from the bottom. Adjusting `viewportY` by the signed scrollback delta keeps the visible top line stable for the normal streaming-output case. If no scrollback lines are added, the viewport should not move. If scrollback is reduced or old lines are dropped, signed delta plus clamping keeps offsets valid; content no longer retained by WASM cannot be preserved.

</details>

### Phase 3 — Add tests

File:

- `lib/scrolling.test.ts`

Add a focused suite such as `describe('preserveScrollOnWrite', () => { ... })` using the existing `createIsolatedTerminal()` pattern. For deterministic assertions, prefer setting `smoothScrollDuration: 0` directly in these new tests if the option works with the existing helper; otherwise wait for the smooth-scroll animation to settle before asserting `viewportY` / emitted scroll values.

Required tests:

1. **Default behavior remains snap-to-bottom**
   - Create a terminal without `preserveScrollOnWrite`.
   - Write enough lines to create scrollback.
   - `scrollLines(-N)` and assert `viewportY === N`.
   - Write one more line.
   - Assert `viewportY === 0`.

2. **Opt-in mode preserves viewport across scrollback growth and emits `onScroll`**
   - Create a terminal with `{ preserveScrollOnWrite: true }`.
   - Register `terminal.onScroll((value) => ...)` before the preserving write.
   - Write enough lines to create scrollback.
   - Scroll up by `N` lines and record `viewportY` and `getScrollbackLength()`.
   - Clear/ignore emissions caused by the setup `scrollLines()` call so the assertion targets the preserving write.
   - Write one or more newline-terminated lines.
   - Record the new scrollback length.
   - Assert `viewportY === oldViewportY + (newScrollbackLength - oldScrollbackLength)`, clamped to the new scrollback length.
   - Assert the final `onScroll` emission for the preserving write matches `Math.floor(terminal.viewportY)`.
   - If the existing test helpers expose stable visible-row text, also assert the top visible row text is unchanged before and after the write.

3. **Opt-in mode does not move viewport when write creates no scrollback growth**
   - Create with `{ preserveScrollOnWrite: true }`.
   - Populate scrollback and scroll up.
   - Write data that does not add a new line / does not grow scrollback.
   - Assert `viewportY` remains unchanged.

4. **Runtime option toggle works**
   - Create a default terminal and verify the default snap-to-bottom behavior.
   - Set `terminal.options.preserveScrollOnWrite = true`.
   - Scroll up again, write one line, and verify preservation behavior.
   - This confirms the option proxy/defaulted options object participates in live behavior.

Test hygiene:

- Dispose terminals and remove containers in `afterEach` or local `try/finally`.
- Prefer deterministic row counts and small terminal dimensions so expected scrollback deltas are easy to reason about.
- Keep assertions focused on #127; do not rewrite existing scrolling tests unless required for integration.

Quality gate after Phase 3:

```bash
bun test lib/scrolling.test.ts
```

### Phase 4 — Full validation

Run the repository’s normal gates before claiming the implementation is done:

```bash
bun run fmt
bun run lint
bun run typecheck
bun test
bun run build
```

If `bun test` hangs after printing successful results, record the printed pass/fail summary and terminate only after confirming the test suite completed. If validation fails for an unrelated pre-existing reason, capture the exact command, failure, and why it is out of scope.

### Phase 5 — Dogfooding and reviewable evidence

Goal: demonstrate the behavior in a real browser terminal surface and produce evidence reviewers can inspect.

Setup:

1. Install dependencies if needed:

   ```bash
   bun install
   ```

2. Start Vite, not a plain static file server:

   ```bash
   bun run dev
   ```

3. Use browser automation with the `agent-browser` skill or equivalent Playwright flow to open a same-origin page, preferably:

   ```text
   http://localhost:8000/demo/scrollbar-test.html
   ```

Dogfood procedure:

1. **Default mode evidence**
   - Create or use a demo terminal with default options.
   - Populate scrollback with many numbered lines.
   - Scroll up until older numbered lines are visible.
   - Trigger a background write, for example by evaluating `term.write('background line\r\n')` in the page context or using an existing demo control.
   - Verify it snaps to the bottom.
   - Capture a screenshot before the write and after the snap.

2. **Opt-in mode evidence**
   - Use the same page context to set `term.options.preserveScrollOnWrite = true`, or instantiate a second terminal with `{ preserveScrollOnWrite: true }` from `/lib/terminal.ts` in the browser page.
   - Populate scrollback with numbered lines.
   - Scroll up and note the visible top line.
   - Trigger several background writes.
   - Verify the visible historical text remains stable while the scrollbar thumb/position updates.
   - Capture before/after screenshots and a short screen recording showing multiple writes without snapping to bottom.

3. **Evidence handling**
   - Save screenshots/recordings outside the checkout, for example under `/tmp/ghostty-web-127-dogfood/`.
   - Attach the final screenshots/recording to the implementation summary or PR using the available attachment flow.
   - Do not commit temporary dogfood pages, scripts, screenshots, or videos.

Suggested evidence checklist:

- `default-before-write.png`: scrolled-up viewport before a default write.
- `default-after-write.png`: viewport snapped to live bottom after default write.
- `preserve-before-writes.png`: scrolled-up viewport with opt-in enabled.
- `preserve-after-writes.png`: same visible content after several background writes.
- `preserve-scroll-on-write.webm` or equivalent short recording demonstrating repeated writes.

## Acceptance criteria

1. `ITerminalOptions` includes `preserveScrollOnWrite?: boolean`.
2. `Terminal` defaults `preserveScrollOnWrite` to `false`.
3. With the default setting, writing while scrolled up still scrolls to the bottom.
4. With `preserveScrollOnWrite: true`, writing while scrolled up preserves the visible historical content by adjusting `viewportY` by scrollback growth and clamping to available scrollback.
5. Opt-in preservation keeps `targetViewportY` synchronized so smooth scrolling does not undo the adjustment.
6. `onScroll` subscribers are notified when preservation changes the viewport, and scrollbar visibility/position is updated consistently with existing scroll behavior.
7. Tests cover default behavior, opt-in preservation, `onScroll` emission during preservation, no-scrollback-growth writes, and runtime toggling through `terminal.options`.
8. Focused and full validation commands pass, or any blocker is reported with exact command output and scope assessment.
9. Manual dogfooding produces reviewable screenshots and a short recording for default vs opt-in behavior.

## Risks and mitigations

- **Risk: Scrollback length can fail to grow for writes that still visually affect the screen.**
  - Mitigation: Only adjust by measured scrollback delta. This preserves the intended streaming-output case without inventing broader viewport semantics.
- **Risk: Smooth-scroll animation target fights the preserved viewport.**
  - Mitigation: Update `targetViewportY` alongside `viewportY`.
- **Risk: Scrollback limit drops old lines.**
  - Mitigation: Clamp to the new scrollback length. Do not attempt to preserve content no longer retained by WASM.
- **Risk: Tests depend on exact WASM scrollback behavior.**
  - Mitigation: Derive expected deltas from `getScrollbackLength()` before/after writes rather than assuming every write produces exactly one scrollback line.
- **Risk: Dogfooding requires page access to a terminal instance.**
  - Mitigation: Prefer browser-page evaluation against the Vite-served app; if the demo does not expose `term`, instantiate a temporary terminal in page context via `await import('/lib/terminal.ts')` rather than committing demo-only controls.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
